### PR TITLE
fix(cicero-ui): prevent backspace at variable start - I78

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -36,4 +36,15 @@ cd packages/storybook
 npm run storybook
 ```
 
+### Develop inside Storybook
+
+While Storybook is running, if you make a change in a package that you want to see reflected in the demo, in a new terminal:
+
+```
+cd packages/<PACKAGE>
+npm run build
+```
+
+Storybook will reload with the applied changes.
+
 [apdev]: https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md

--- a/packages/cicero-ui/src/lib/ContractEditor/plugins/withVariables.js
+++ b/packages/cicero-ui/src/lib/ContractEditor/plugins/withVariables.js
@@ -57,6 +57,9 @@ export const isEditableVariable = (lockText, editor, event) => {
   const nextNode = Editor.next(editor, { at: editor.selection.focus.path });
   // if the current focus is at the end of a node & the next node is a variable allow editing
   if (nextNode && nextNode[0].type === VARIABLE && textLength === editor.selection.focus.offset) {
+    if (event.inputType === 'deleteContentBackward') {
+      return false;
+    }
     return true;
   }
   return inVariable(editor);


### PR DESCRIPTION
# Closes #78
Prevents deleting backwards at the beginning of a variable

### Changes
- Provide more documentation for reloading in local development
- Check for backward delete event if at the beginning of a variable

### Flags
- N/A

### Author Checklist
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`