### PR TITLE
fix(cicero-ui): remove semantic-ui stylesheet

### DIFF
--- a/packages/cicero-ui/src/lib/index.js
+++ b/packages/cicero-ui/src/lib/index.js
@@ -3,7 +3,6 @@ import ErrorLogger from './ErrorLogger';
 import Navigation from './Navigation';
 import Library from './Library';
 import Tile from './Tile';
-import 'semantic-ui-css/semantic.min.css';
 
 export {
   ContractEditor,


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

This fixes an issue where semantic-ui styles were interfering with other styles when using this app in a third party. For reference, the third party also uses semantic-ui and includes semantic-ui's css stylesheet in the head of its html page.

Removing this import does not seem to have any negative impact. Both markdown-editor and concerto-ui-react also use semantic-ui and did not have this import in the library itself (I do see it in the story for Contract Editor and Markdown Editor).