### PR TITLE
fix(Clause): pass readOnly props to clause to not render icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@accordproject/web-components",
-	"version": "0.90.0",
+	"version": "0.91.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/cicero-ui/src/lib/ContractEditor/index.js
+++ b/packages/cicero-ui/src/lib/ContractEditor/index.js
@@ -79,6 +79,7 @@ const ContractEditor = (props) => {
           templateUri={element.data.src}
           clauseId={element.data.clauseid}
           clauseProps={props.clauseProps}
+          readOnly={props.readOnly}
           {...attributes}
         >
             {children}

--- a/packages/cicero-ui/src/lib/components/Clause/index.js
+++ b/packages/cicero-ui/src/lib/components/Clause/index.js
@@ -97,7 +97,6 @@ const ClauseComponent = React.forwardRef((props, ref) => {
           contentEditable={false}
           suppressContentEditableWarning={true}
           style={{ userSelect: 'none' }}
-          
         >
           {(hoveringHeader && header.length > 54)
             && <S.HeaderToolTipWrapper>


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #86 
<!--- Provide an overall summary of the pull request -->
fix(Clause): pass readOnly props to clause to not render icons
