### PR TITLE
feat(withClauses): adds canAddClause query to editor

### DIFF
--- a/packages/cicero-ui/src/lib/ContractEditor/plugins/withClauses.js
+++ b/packages/cicero-ui/src/lib/ContractEditor/plugins/withClauses.js
@@ -143,6 +143,13 @@ const withClauses = (editor, withClausesProps) => {
     return true;
   };
 
+  editor.canAddClause = () => {
+    // do not allow adding a clause in nested elements (ie. lists, other clauses)
+    if (editor.selection) return (editor.selection.anchor.path.length <= 2);
+    // do allow adding a clause if no selection (can add it to end of doc)
+    return true;
+  };
+
   return editor;
 };
 


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

feat(withClauses): adds canAddClause query to editor to call when adding a clause to prevent adding clauses in nested elements such as lists or other clauses