### PR TITLE
style(Library): Add utility class to library cards wrapper

### DIFF
--- a/packages/cicero-ui/src/lib/Library/README.md
+++ b/packages/cicero-ui/src/lib/Library/README.md
@@ -41,6 +41,7 @@ Optional keys are: `displayName`, `logoUrl` and `itemType` (for heterogeneous li
 The component provides classes which can be used to apply custom styles to its individual parts.
 
 - `cicero-ui__library-search-input` : search input.
+- `cicero-ui__library-cards-wrapper` : library cards wrapper element.
 - `cicero-ui__library-card` : library card. An additional class of `item.itemType` will be added to the card,
 so different CSS selectors can be used based on the item's `itemType` value.
 - `cicero-ui__library-card-content` : content element inside a library item card.

--- a/packages/cicero-ui/src/lib/Library/index.js
+++ b/packages/cicero-ui/src/lib/Library/index.js
@@ -169,7 +169,7 @@ const LibraryComponent = (props) => {
         />
         <NewItemComponent onAddItem={props.onAddItem} />
       </Functionality>
-      <LibraryItemCards>
+      <LibraryItemCards className="cicero-ui__library-cards-wrapper">
         {
           filtered.length
             ? filtered.map(item => (


### PR DESCRIPTION
### Changes
Adds `cicero-ui__library-cards-wrapper` CSS class to library cards wrapper element. Helps in setting the desired height. It is useful when the collection is large.

### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation
- [x] Merging to `master` from `fork:branchname`