### PR TITLE
feat(Clause): update styling so less space at top of clause

### DIFF
--- a/packages/cicero-ui/src/lib/components/styles.js
+++ b/packages/cicero-ui/src/lib/components/styles.js
@@ -9,7 +9,7 @@ export const ClauseWrapper = styled.div`
   border: 1px solid #19C6C7;
   border-radius: 3px;
   grid-template-columns: 10px 375px 1fr 25px 25px 25px 10px;
-  grid-template-rows: 11px 11px 1fr;
+  grid-template-rows: 0px 10px 1fr;
   grid-template-areas: "one two three four five six seven"
                        "eight nine ten eleven twelve thirteen fourteen"
                        "fifteen sixteen seventeen eighteen nineteen twenty twentyone";
@@ -56,8 +56,7 @@ export const ClauseHeader = styled.div`
   background: linear-gradient(180deg, #FFFFFF 0%, #F4F6FC 100%);
   align-self: center;
   justify-self: start;
-  margin-top: -16px;
-  margin-bottom: 6px;
+  margin-bottom: 9px;
   padding: 3px;
   color: #696969;
   line-height: 14px;
@@ -101,7 +100,7 @@ const IconWrapper = styled.div`
   background: linear-gradient(180deg, #FFF 0%, #F4F6FC 100%);
   position: relative;
   z-index: 1;
-  margin-top: -18px;
+  margin-bottom: 9px;
   padding: 4px;
   place-self: center;
   transition-duration: 0.5s;


### PR DESCRIPTION
feat(Clause): update styling so less space at top of clause
Signed-off-by: Diana Lease <dianarlease@gmail.com>

Shown below with not hovering and hovering for different clauses.
![Screen Shot 2020-05-22 at 6 26 02 PM](https://user-images.githubusercontent.com/20543103/82713730-0601ea80-9c5a-11ea-9190-61330ca4f118.png)
![Screen Shot 2020-05-22 at 6 26 14 PM](https://user-images.githubusercontent.com/20543103/82713732-0601ea80-9c5a-11ea-88d6-745531c1bf13.png)
![Screen Shot 2020-05-22 at 6 26 28 PM](https://user-images.githubusercontent.com/20543103/82713733-0601ea80-9c5a-11ea-89af-6a4491af77c5.png)
![Screen Shot 2020-05-22 at 6 26 35 PM](https://user-images.githubusercontent.com/20543103/82713734-069a8100-9c5a-11ea-9f2a-0dea9e5bc987.png)
