### PR TITLE
feat(markdown-editor): generate id on whole header

### DIFF
--- a/packages/markdown-editor/src/lib/utilities/generateId.js
+++ b/packages/markdown-editor/src/lib/utilities/generateId.js
@@ -1,5 +1,8 @@
 // https://github.com/thlorenz/anchor-markdown-header/blob/87e4cca4618271e363f4af9697df0f73f23b3d3f/anchor-markdown-header.js#L20
-const generateId = element => element.children[0].text.replace(/ /g, '-')
+
+const childReducer = (children) => children.reduce((acc, cur) => `${acc}${cur.text}`, '');
+
+const generateId = element => childReducer(element.children).replace(/ /g, '-')
   // escape codes
   .replace(/%([abcdef]|\d){2,2}/ig, '')
   // single chars that are removed


### PR DESCRIPTION
# No Issue
Improve `id` generation for headings

### Changes
- Reduce all children of a header to include formatted text

### Related Issues
- https://github.com/accordproject/markdown-editor/pull/377

### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `master` from `fork:branchname`