### PR TITLE
fix(ContractEditor): correct onClauseUpdated call

### DIFF
--- a/packages/cicero-ui/src/lib/ContractEditor/README.md
+++ b/packages/cicero-ui/src/lib/ContractEditor/README.md
@@ -61,7 +61,7 @@ render(<ContractEditorRenderer />, document.getElementById('root'));
 
 #### Values
 
-- `value` [OPTIONAL]: An `object` which is the initial contents of the editor.
+- `value` [OPTIONAL]: An `array` which is the initial contents of the editor.
 - `lockText` [OPTIONAL]: A `boolean` to lock all non variable text.
 - `readOnly` [OPTIONAL]: A `boolean` to lock all text and remove the formatting toolbar.
 - `activeButton` [OPTIONAL]: Optional `object` to change formatting button active state color
@@ -69,10 +69,16 @@ render(<ContractEditorRenderer />, document.getElementById('root'));
 
 #### Functionality
 
-- `onChange` [OPTIONAL]: A callback `function` called when the contents of the editor change.
-- `loadTemplateObject` [OPTIONAL]: A callback `function` to load a template.
-- `onClauseUpdated` [OPTIONAL]: A callback `function` called when text inside of a clause is changed.
-- `pasteToContract` [OPTIONAL]: A callback `function` to load a clause template via copy/paste.
+- `onChange` [OPTIONAL]: A callback `function` called when the contents of the editor change. Argument:
+  - `value`: The Slate nodes `array` representing all the rich text
+- `loadTemplateObject` [OPTIONAL]: A callback `function` to load a template. Argument:
+  - `uri`: URI `string` source for loading the template
+- `onClauseUpdated` [OPTIONAL]: A callback `function` called when text inside of a clause is changed. Arguments:
+  - `clause`: The Slate node `object` representation of the clause
+  - `justAdded`:  A `boolean` indicating if this was just added (likely via a paste action)
+- `pasteToContract` [OPTIONAL]: A callback `function` to load a clause template via copy/paste. Arguments:
+  - `clauseid`: Data `string` from the clause in Slate to indicate a `uuid`
+  - `src`: URI `string` source for loading the template
 
 ### Available Functionality
 

--- a/packages/cicero-ui/src/lib/ContractEditor/plugins/withClauses.js
+++ b/packages/cicero-ui/src/lib/ContractEditor/plugins/withClauses.js
@@ -114,7 +114,7 @@ const withClauses = (editor, withClausesProps) => {
 
         clausesToParseAndPaste.forEach((clause) => {
           pasteToContract(clause.data.clauseid, clause.data.src);
-          onClauseUpdated(editor, clause);
+          onClauseUpdated(clause, true);
         });
 
         const NEW_HTML_DOM = htmlTransformer


### PR DESCRIPTION
# No Issue
`onClauseUpdated` was being passed a clause node in all cases except this one, which passed the editor instead

### Changes
- Update documentation on optional functionality
- Pass the clause node and a boolean instead of the editor `onClauseUpdated`

### Flags
- Unsure how this was introduced from the [original code](https://github.com/accordproject/cicero-ui/blob/master/src/ContractEditor/plugins/withClauses.js#L119)

### Related
- PR https://github.com/accordproject/web-components/pull/4

### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`