### PR TITLE
fix(Clause): fixes clauses being uneditable in safari when draggable - #115 

### DIFF
--- a/packages/ui-contract-editor/src/lib/components/Clause/index.js
+++ b/packages/ui-contract-editor/src/lib/components/Clause/index.js
@@ -106,6 +106,8 @@ const ClauseComponent = React.forwardRef((props, ref) => {
     }
   };
 
+  const setDraggable = (event, draggable) => event.target.closest('.ui-contract-editor__clause').setAttribute('draggable', draggable);
+
   return (
     <ClauseContext.Provider value={hovering}>
       <S.ClauseWrapper
@@ -235,7 +237,10 @@ const ClauseComponent = React.forwardRef((props, ref) => {
             </S.DeleteWrapper>
           </>
         }
-        <S.ClauseBody>
+        <S.ClauseBody
+          onMouseEnter={(e) => setDraggable(e, false)}
+          onMouseLeave={(e) => setDraggable(e, true)}
+        >
             {props.children}
         </S.ClauseBody>
       </S.ClauseWrapper>


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #115 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Adds a workaround for children of draggable elements not being editable in Safari by removing draggable attribute when user is inside the text of a clause