### PR TITLE
feat(*): add drag and drop for images

### DIFF
--- a/packages/ui-contract-editor/src/lib/ContractEditor/index.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/index.js
@@ -138,16 +138,19 @@ const ContractEditor = (props) => {
   };
 
   const onDragOver = (editor, event) => {
-    event.preventDefault();
+    event.stopPropagation();
     event.dataTransfer.dropEffect = 'move';
   };
 
+  // return true if should continue through to next handler, else return false
   const onDrop = (editor, event) => {
     event.preventDefault();
+    const targetRange = ReactEditor.findEventRange(editor, event);
+    const [targetIsClause] = Editor.nodes(editor, { match: n => n.type === 'clause', at: targetRange });
+    if (targetIsClause) return false; // do not allow dropping inside of a clause
     const sourceRange = JSON.parse(event.dataTransfer.getData('text'));
     const [clauseNode] = Editor.nodes(editor, { match: n => n.type === 'clause', at: sourceRange });
-    if (!clauseNode) return; // only allow dropping of clause nodes
-    const targetRange = ReactEditor.findEventRange(editor, event);
+    if (!clauseNode) return true; // continue to next handler if not a clause
     const node = ReactEditor.toSlateNode(editor, event.target);
     const path = ReactEditor.findPath(editor, node);
 
@@ -180,6 +183,7 @@ const ContractEditor = (props) => {
     Transforms.collapse(editor, { edge });
     Transforms.removeNodes(editor, { at: sourceRange.anchor.path, match: n => n.type === 'clause' });
     Transforms.insertNodes(editor, clauseNode[0]);
+    return false;
   };
 
   return (
@@ -202,6 +206,7 @@ const ContractEditor = (props) => {
   />
   );
 };
+
 
 /**
  * The property types for this component

--- a/packages/ui-markdown-editor/src/lib/plugins/withImages.js
+++ b/packages/ui-markdown-editor/src/lib/plugins/withImages.js
@@ -15,7 +15,6 @@ import { POPUP_STYLE } from '../utilities/constants';
 import Button from '../components/Button';
 
 const StyledImage = styled.img`
-  display: block;
   max-width: 100%;
   max-height: 20em;
   box-shadow: ${props => (props.shadow ? '0 0 0 3px #B4D5FF' : 'none')};


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- feat(*): add drag and drop for images

### Flags
- Images are inlines and should be displayed as such (previously, we were displaying them as "block" elements
- Therefore, I am now displaying them as inline and allowing them to be dropped inline (unlike clauses which we force to be dropped at the top level)

### Related Issues
- Issue #61