### PR TITLE
fix(contract-editor): protect clause from backspace - I122

### DIFF
--- a/packages/ui-contract-editor/src/lib/ContractEditor/index.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/index.js
@@ -119,8 +119,7 @@ const ContractEditor = (props) => {
   const canKeyDown = (editor, event) => {
     if (
       (event.keyCode || event.charCode) === 8
-      && Node.get(editor, editor.selection.focus.path).text.length === 0
-      && Point.equals(Editor.end(editor, []), editor.selection.anchor)
+      && Point.equals(Editor.start(editor, editor.selection.anchor.path), editor.selection.anchor)
     ) {
       const [match] = Editor
         .nodes(editor, { at: Editor.previous(editor)[1], match: n => n.type === CLAUSE });


### PR DESCRIPTION
# Closes #122
Enhance backspace checking to handle backspacing immediately after a clause template

### Changes
- Check used to be if the cursor was at the end of the document, without a selection, and after a clause template
- Check is now if the cursor is beginning at the start of a node and the previous node is a clause template

### Flags
- Publishing this will include the parser changes upstream

### Related Issues
- Pull Request https://github.com/accordproject/cicero-ui/pull/412

### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `master` from `fork:branchname`