### PR TITLE
refactor(*): upgrade to new parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,18 @@
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.20.11-20200626053054",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.20.11-20200626053054.tgz",
-			"integrity": "sha512-oCSvDeilk2+DWLNd3I1rwuQfoN56ByDt6QW8X4pR4iyl3we2Gj6k8zK6RtfZvTHzoE81/h8Xnwx3JtIbeU+/xg==",
+			"version": "0.20.11-20200626165149",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.20.11-20200626165149.tgz",
+			"integrity": "sha512-TNwNLXXrwBtAsZD9CPSwXwo2yUbHLUkhetNdrUMluoz6vKkrScm5JIJl7IVOfzHVifORgsplkw51LGqaH7axTg==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.7",
 				"@accordproject/ergo-compiler": "0.20.10",
 				"@accordproject/ergo-engine": "0.20.10",
-				"@accordproject/markdown-cicero": "0.11.4-20200626045711",
-				"@accordproject/markdown-common": "0.11.4-20200626045711",
-				"@accordproject/markdown-html": "0.11.4-20200626045711",
-				"@accordproject/markdown-template": "0.11.4-20200626045711",
+				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
+				"@accordproject/markdown-common": "0.11.4-20200626164143",
+				"@accordproject/markdown-html": "0.11.4-20200626164143",
+				"@accordproject/markdown-slate": "0.11.4-20200626164143",
+				"@accordproject/markdown-template": "0.11.4-20200626164143",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
@@ -29,31 +30,6 @@
 				"slash": "3.0.0",
 				"uuid": "3.3.2",
 				"xregexp": "4.2.4"
-			},
-			"dependencies": {
-				"@accordproject/markdown-cicero": {
-					"version": "0.11.4-20200626045711",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200626045711.tgz",
-					"integrity": "sha512-F/6eb5lvTy+a0ltUa4xGhFSdlEkp52d8vi3J/r90Rhixql2d5E7XlAZ5m62H4WKnBoQZh1b6ipVWXlX8lsJvuA==",
-					"requires": {
-						"@accordproject/concerto-core": "^0.82.7",
-						"@accordproject/markdown-common": "0.11.4-20200626045711",
-						"jsome": "2.5.0",
-						"winston": "3.2.1",
-						"xmldom": "^0.1.27"
-					}
-				},
-				"@accordproject/markdown-html": {
-					"version": "0.11.4-20200626045711",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.4-20200626045711.tgz",
-					"integrity": "sha512-CW/G5rBUoXs57VokXQcNACs4LjV20raxj4qtzIb8EM8hgihi4uwwYQhe/PyvLrOJ096/2V0xspnS0janrl7RZw==",
-					"requires": {
-						"@accordproject/markdown-cicero": "0.11.4-20200626045711",
-						"@accordproject/markdown-common": "0.11.4-20200626045711",
-						"jsdom": "^15.2.1",
-						"type-of": "^2.0.1"
-					}
-				}
 			}
 		},
 		"@accordproject/concerto-core": {
@@ -124,35 +100,21 @@
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.11.4-20200626055423",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200626055423.tgz",
-			"integrity": "sha512-MrgGmyl65/bJlCp649nWfynh7VyLa57SCrGCZ7kXz5Py0QJ1Ew2DakzIe8rUAzn23HV0IBfWMrvC0jPQRU2vJg==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-z/7nXC45GfXjC1FTuq7dLr6qczkSlyHDaG5Y69/yyvQO9dcgcHdGfxaDsL3GeyVESCyiFkv0DTwm+ttWjtjTAw==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-common": "0.11.4-20200626055423",
+				"@accordproject/markdown-common": "0.11.4-20200626164143",
 				"jsome": "2.5.0",
 				"winston": "3.2.1",
 				"xmldom": "^0.1.27"
-			},
-			"dependencies": {
-				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200626055423",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
-					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
-					"requires": {
-						"@accordproject/concerto-core": "^0.82.7",
-						"jsome": "2.5.0",
-						"markdown-it": "^11.0.0",
-						"winston": "3.2.1",
-						"xmldom": "^0.1.27"
-					}
-				}
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.11.4-20200626045711",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626045711.tgz",
-			"integrity": "sha512-UaBFff1SWtv1bhLittzo5/rEsevZMbXu6xbuklUZXqM+jbVryU2kUzRw8Smvz4aBHuGzTsOWqLA8tB4bOB7Nwg==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-kxYB3VSAHA3SVCoRBmFILjzwj2fwUFGd0Y3uHs4POvUlElrvh3kedZ/lTtQqJOQtnTCiSDIbaD/tpr2brIcAgA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
 				"jsome": "2.5.0",
@@ -162,176 +124,83 @@
 			}
 		},
 		"@accordproject/markdown-docx": {
-			"version": "0.11.4-20200626055423",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.11.4-20200626055423.tgz",
-			"integrity": "sha512-A3seGtOSbzKQPbFwQ+1rkyiyGfybK5tbEdSgJOJxZFEMxwAQ8xM4wKhMNM+Gk/V8oRI05+dG128emxY7MLAHTA==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-b20qvnor3SSoesM1oxEZCbZYm0ltRVkYuuB0YaY6prtdR1R0rAtpFuCmwOy3jdAo8DIAvaTcjdtQWMyAJDMNXA==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200626055423",
-				"@accordproject/markdown-common": "0.11.4-20200626055423",
+				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
+				"@accordproject/markdown-common": "0.11.4-20200626164143",
 				"mammoth": "^1.4.9"
-			},
-			"dependencies": {
-				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200626055423",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
-					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
-					"requires": {
-						"@accordproject/concerto-core": "^0.82.7",
-						"jsome": "2.5.0",
-						"markdown-it": "^11.0.0",
-						"winston": "3.2.1",
-						"xmldom": "^0.1.27"
-					}
-				}
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.11.4-20200626055423",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.4-20200626055423.tgz",
-			"integrity": "sha512-DUpE2OaQx5FXH7u54AmYwMPBGSbWngYIT8ILi11rmZ/VWWOWNGafmNV86x2zo3aRpqB00GSRpXVh12afUDWU+w==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-6Tq8g+0vOmP7ybLmbty/STU6CeF71ixIag2iWxiYzZZPSJlbMLdpjn4RtDfAAGU/2TlyDR5O8Ns16Qb32X1IGw==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200626055423",
-				"@accordproject/markdown-common": "0.11.4-20200626055423",
+				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
+				"@accordproject/markdown-common": "0.11.4-20200626164143",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
-			},
-			"dependencies": {
-				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200626055423",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
-					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
-					"requires": {
-						"@accordproject/concerto-core": "^0.82.7",
-						"jsome": "2.5.0",
-						"markdown-it": "^11.0.0",
-						"winston": "3.2.1",
-						"xmldom": "^0.1.27"
-					}
-				}
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.11.4-20200626045711",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.11.4-20200626045711.tgz",
-			"integrity": "sha512-aiAXmxQj2Z0uCnHvnFksMGU2S9LdZnDTlciZpjSQaaWgIR1v3KJ6hdrq6OeXKOP5RqY4NrbLYhpQPZmGb7fEWQ==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-BnkHUZr4xcs9V4OGv6E/bgoq82sUQW/UBkELkD5SModK3U/XhIcJpZUThQ8PwFS+M+1JKI7yOSItapK2ZMfdIQ==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-pdf": {
-			"version": "0.11.4-20200626055423",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.11.4-20200626055423.tgz",
-			"integrity": "sha512-Nrk4TsFij5KLXB2f67VaYNAdaukcjnfxLOTV+0LUnx8ihryiIEirPcPpzpu1Z9gYQcwwP0MERXETj5cPxQth9Q==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-EXR4CUj8iEkKIywUQOH7vV9POTJfSg4yqXolTfFmeeMmWAEhHjLOQhvarmn67VhPHtFmFggaRtCuGIWAdhUWXg==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200626055423",
-				"@accordproject/markdown-common": "0.11.4-20200626055423",
+				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
+				"@accordproject/markdown-common": "0.11.4-20200626164143",
 				"easy-pdf-parser": "0.0.4",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
-			},
-			"dependencies": {
-				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200626055423",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
-					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
-					"requires": {
-						"@accordproject/concerto-core": "^0.82.7",
-						"jsome": "2.5.0",
-						"markdown-it": "^11.0.0",
-						"winston": "3.2.1",
-						"xmldom": "^0.1.27"
-					}
-				}
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.11.4-20200626055423",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.11.4-20200626055423.tgz",
-			"integrity": "sha512-N6GGNhaFJak+JHh3llkk1Clo8iCqKxzQm2olOs4rtqCvLNLqZISjPIh2cFtJIIt/YdP3V3wRj0rIKxCa4tlzdA==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-stjyiy6i+6UNWf1F7rKOfqp1/TxfU3WYIDm+FViXbqPvAlLIatyh1CwmqqlmTvMmqx9hiI88sqAjNSSiMMT78w==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200626055423"
+				"@accordproject/markdown-cicero": "0.11.4-20200626164143"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.11.4-20200626045711",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.11.4-20200626045711.tgz",
-			"integrity": "sha512-/yHO/JOHe7G1RM3LsUJ2wSiK69HmLKduSJqzntemy07lA0Wyj+2UXHJHtWtmUS9977FP7Dh54RS+VaxoY5sFkA==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-ZKCFzC4dhAU8apKU8ajxfvdI+OUdAjQTcbh6A0GJ9YIu0PB5CucS/o0jxn0SK0pyRJHkHNd0ytaj7UOguJo7vg==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-cicero": "0.11.4-20200626045711",
-				"@accordproject/markdown-common": "0.11.4-20200626045711",
-				"@accordproject/markdown-it-template": "0.11.4-20200626045711",
+				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
+				"@accordproject/markdown-common": "0.11.4-20200626164143",
+				"@accordproject/markdown-it-template": "0.11.4-20200626164143",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",
 				"uuid": "3.3.2"
-			},
-			"dependencies": {
-				"@accordproject/markdown-cicero": {
-					"version": "0.11.4-20200626045711",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200626045711.tgz",
-					"integrity": "sha512-F/6eb5lvTy+a0ltUa4xGhFSdlEkp52d8vi3J/r90Rhixql2d5E7XlAZ5m62H4WKnBoQZh1b6ipVWXlX8lsJvuA==",
-					"requires": {
-						"@accordproject/concerto-core": "^0.82.7",
-						"@accordproject/markdown-common": "0.11.4-20200626045711",
-						"jsome": "2.5.0",
-						"winston": "3.2.1",
-						"xmldom": "^0.1.27"
-					}
-				}
 			}
 		},
 		"@accordproject/markdown-transform": {
-			"version": "0.11.4-20200626055423",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.11.4-20200626055423.tgz",
-			"integrity": "sha512-sPuRcPR+1/xKdAzo4nl+KHLIMdWwPfkzNd4lBY9IQtsdaK5DTUB0EUJSsdzqjdsbpTtLUbAFsejcM9GWQdYUdw==",
+			"version": "0.11.4-20200626164143",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.11.4-20200626164143.tgz",
+			"integrity": "sha512-0sn0Ova3SdDfWM2PulJJjo0vCqqwRv2K0/f97DpkSAWJ20OkOi+tZWsmbGXVUWWh1+vWXTo7zFoBRHvFP3JwFQ==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-cicero": "0.11.4-20200626055423",
-				"@accordproject/markdown-common": "0.11.4-20200626055423",
-				"@accordproject/markdown-docx": "0.11.4-20200626055423",
-				"@accordproject/markdown-html": "0.11.4-20200626055423",
-				"@accordproject/markdown-pdf": "0.11.4-20200626055423",
-				"@accordproject/markdown-slate": "0.11.4-20200626055423",
-				"@accordproject/markdown-template": "0.11.4-20200626055423",
+				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
+				"@accordproject/markdown-common": "0.11.4-20200626164143",
+				"@accordproject/markdown-docx": "0.11.4-20200626164143",
+				"@accordproject/markdown-html": "0.11.4-20200626164143",
+				"@accordproject/markdown-pdf": "0.11.4-20200626164143",
+				"@accordproject/markdown-slate": "0.11.4-20200626164143",
+				"@accordproject/markdown-template": "0.11.4-20200626164143",
 				"dijkstrajs": "^1.0.1"
-			},
-			"dependencies": {
-				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200626055423",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
-					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
-					"requires": {
-						"@accordproject/concerto-core": "^0.82.7",
-						"jsome": "2.5.0",
-						"markdown-it": "^11.0.0",
-						"winston": "3.2.1",
-						"xmldom": "^0.1.27"
-					}
-				},
-				"@accordproject/markdown-it-template": {
-					"version": "0.11.4-20200626055423",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.11.4-20200626055423.tgz",
-					"integrity": "sha512-BUSrYza3Y9rBEIyg47w5cQnE37+f1zVffaZU4n4XHQog9jk0eQcL2gKSNcFkwpGPN3xl+eLb/jvvCdz5a1tWxw==",
-					"requires": {
-						"markdown-it": "^11.0.0"
-					}
-				},
-				"@accordproject/markdown-template": {
-					"version": "0.11.4-20200626055423",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.11.4-20200626055423.tgz",
-					"integrity": "sha512-OzzFzSokSVb4XqCgFwAES64IgqI9L2173AG9juYUUQ7KDIUzDqSAYoVmpgQgvKVQHTGiOKo7wL99I98QYEv1/g==",
-					"requires": {
-						"@accordproject/concerto-core": "^0.82.7",
-						"@accordproject/markdown-cicero": "0.11.4-20200626055423",
-						"@accordproject/markdown-common": "0.11.4-20200626055423",
-						"@accordproject/markdown-it-template": "0.11.4-20200626055423",
-						"markdown-it": "^11.0.0",
-						"moment-mini": "2.22.1",
-						"parsimmon": "^1.13.0",
-						"uuid": "3.3.2"
-					}
-				}
 			}
 		},
 		"@babel/cli": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,26 +5,24 @@
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.20.10",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.20.10.tgz",
-			"integrity": "sha512-9faG7kVWJRz7chteVlwsaLpMbS3yLW35tZ0yGkuuiGFvVeZB3hbV5Sdzl21qOri14RqFp5oPgiPS83iFOU/IOw==",
+			"version": "0.20.11-20200626053054",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.20.11-20200626053054.tgz",
+			"integrity": "sha512-oCSvDeilk2+DWLNd3I1rwuQfoN56ByDt6QW8X4pR4iyl3we2Gj6k8zK6RtfZvTHzoE81/h8Xnwx3JtIbeU+/xg==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.7",
 				"@accordproject/ergo-compiler": "0.20.10",
 				"@accordproject/ergo-engine": "0.20.10",
-				"@accordproject/markdown-cicero": "0.10.4",
-				"@accordproject/markdown-common": "0.10.4",
-				"@accordproject/markdown-html": "0.10.4",
+				"@accordproject/markdown-cicero": "0.11.4-20200626045711",
+				"@accordproject/markdown-common": "0.11.4-20200626045711",
+				"@accordproject/markdown-html": "0.11.4-20200626045711",
+				"@accordproject/markdown-template": "0.11.4-20200626045711",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
 				"json-stable-stringify": "1.0.1",
 				"jszip": "3.2.1",
 				"moment-mini": "2.22.1",
-				"moo": "0.5.0",
-				"nearley": "2.16.0",
 				"node-cache": "4.2.0",
-				"nunjucks": "3.2.0",
 				"request": "2.88.0",
 				"request-promise-native": "1.0.7",
 				"semver": "6.2.0",
@@ -34,26 +32,24 @@
 			},
 			"dependencies": {
 				"@accordproject/markdown-cicero": {
-					"version": "0.10.4",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.10.4.tgz",
-					"integrity": "sha512-GTMXcs6wJ+Roj2FG9t1qxHmsLDPjj5zywLifX+4FFnUi2eIaH3wThzuo0MrCnYs3bKuGHvANYrDXQawOhXiNyg==",
+					"version": "0.11.4-20200626045711",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200626045711.tgz",
+					"integrity": "sha512-F/6eb5lvTy+a0ltUa4xGhFSdlEkp52d8vi3J/r90Rhixql2d5E7XlAZ5m62H4WKnBoQZh1b6ipVWXlX8lsJvuA==",
 					"requires": {
-						"@accordproject/concerto-core": "^0.82.6",
-						"@accordproject/markdown-common": "0.10.4",
-						"commonmark": "^0.29.0",
+						"@accordproject/concerto-core": "^0.82.7",
+						"@accordproject/markdown-common": "0.11.4-20200626045711",
 						"jsome": "2.5.0",
-						"sax": "^1.2.4",
 						"winston": "3.2.1",
 						"xmldom": "^0.1.27"
 					}
 				},
 				"@accordproject/markdown-html": {
-					"version": "0.10.4",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.10.4.tgz",
-					"integrity": "sha512-MTZScjZHOpk0yJG1R2n+LpbLusNbAkdHQKZitydcQioAXvoMhJisZ54Px33ZzETrqNKtIJoOvpxI01UOf9VYQA==",
+					"version": "0.11.4-20200626045711",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.4-20200626045711.tgz",
+					"integrity": "sha512-CW/G5rBUoXs57VokXQcNACs4LjV20raxj4qtzIb8EM8hgihi4uwwYQhe/PyvLrOJ096/2V0xspnS0janrl7RZw==",
 					"requires": {
-						"@accordproject/markdown-cicero": "0.10.4",
-						"@accordproject/markdown-common": "0.10.4",
+						"@accordproject/markdown-cicero": "0.11.4-20200626045711",
+						"@accordproject/markdown-common": "0.11.4-20200626045711",
 						"jsdom": "^15.2.1",
 						"type-of": "^2.0.1"
 					}
@@ -128,21 +124,21 @@
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.11.4-20200618182921",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200618182921.tgz",
-			"integrity": "sha512-TlRRxQXQfcMQuxHPLFvdNzZJ5kb9Izkczq7anvsO33Xgs4cpCuUUzJ/im1hIUVEFVQmgzdjG1Pm4UD5KjRJNQA==",
+			"version": "0.11.4-20200626055423",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200626055423.tgz",
+			"integrity": "sha512-MrgGmyl65/bJlCp649nWfynh7VyLa57SCrGCZ7kXz5Py0QJ1Ew2DakzIe8rUAzn23HV0IBfWMrvC0jPQRU2vJg==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-common": "0.11.4-20200618182921",
+				"@accordproject/markdown-common": "0.11.4-20200626055423",
 				"jsome": "2.5.0",
 				"winston": "3.2.1",
 				"xmldom": "^0.1.27"
 			},
 			"dependencies": {
 				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200618182921",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200618182921.tgz",
-					"integrity": "sha512-ukIR1gTK4aE+H9gQ7bR+UKlRM06j+/YOysWRyRgVqd4OPKF8ocF2xBLUq4KUymbBoTL/q+MWZvIjnBRuteY2/Q==",
+					"version": "0.11.4-20200626055423",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
+					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
 					"requires": {
 						"@accordproject/concerto-core": "^0.82.7",
 						"jsome": "2.5.0",
@@ -154,32 +150,31 @@
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.10.4.tgz",
-			"integrity": "sha512-2R/p8xrTALWBctRyIiatv5GEWLb2sU5YtTrhtzgYngPdSNzUmMQ3LTHTC5MW3nIzEaScRpFwDdI9vukDihWOhw==",
+			"version": "0.11.4-20200626045711",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626045711.tgz",
+			"integrity": "sha512-UaBFff1SWtv1bhLittzo5/rEsevZMbXu6xbuklUZXqM+jbVryU2kUzRw8Smvz4aBHuGzTsOWqLA8tB4bOB7Nwg==",
 			"requires": {
-				"@accordproject/concerto-core": "^0.82.6",
-				"commonmark": "^0.29.0",
+				"@accordproject/concerto-core": "^0.82.7",
 				"jsome": "2.5.0",
-				"sax": "^1.2.4",
+				"markdown-it": "^11.0.0",
 				"winston": "3.2.1",
 				"xmldom": "^0.1.27"
 			}
 		},
 		"@accordproject/markdown-docx": {
-			"version": "0.11.4-20200618182921",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.11.4-20200618182921.tgz",
-			"integrity": "sha512-DB/Dcu/O9yWdNq817nkvavyM+y9YzatrAyKEjuGqbzeFHyzF2rN3WZjLHdWbogcssMhJFyhOpV04SJWTPtA0Rg==",
+			"version": "0.11.4-20200626055423",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.11.4-20200626055423.tgz",
+			"integrity": "sha512-A3seGtOSbzKQPbFwQ+1rkyiyGfybK5tbEdSgJOJxZFEMxwAQ8xM4wKhMNM+Gk/V8oRI05+dG128emxY7MLAHTA==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200618182921",
-				"@accordproject/markdown-common": "0.11.4-20200618182921",
+				"@accordproject/markdown-cicero": "0.11.4-20200626055423",
+				"@accordproject/markdown-common": "0.11.4-20200626055423",
 				"mammoth": "^1.4.9"
 			},
 			"dependencies": {
 				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200618182921",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200618182921.tgz",
-					"integrity": "sha512-ukIR1gTK4aE+H9gQ7bR+UKlRM06j+/YOysWRyRgVqd4OPKF8ocF2xBLUq4KUymbBoTL/q+MWZvIjnBRuteY2/Q==",
+					"version": "0.11.4-20200626055423",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
+					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
 					"requires": {
 						"@accordproject/concerto-core": "^0.82.7",
 						"jsome": "2.5.0",
@@ -191,20 +186,20 @@
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.11.4-20200618182921",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.4-20200618182921.tgz",
-			"integrity": "sha512-D9vDo5C5uuu6eNMyAFm3JMO8pCCsa36TVc80ynbh9AkXS0PdbFNMm1/ApJY0aqrXrjSHLY+W2NOGNGsyn/VVhQ==",
+			"version": "0.11.4-20200626055423",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.4-20200626055423.tgz",
+			"integrity": "sha512-DUpE2OaQx5FXH7u54AmYwMPBGSbWngYIT8ILi11rmZ/VWWOWNGafmNV86x2zo3aRpqB00GSRpXVh12afUDWU+w==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200618182921",
-				"@accordproject/markdown-common": "0.11.4-20200618182921",
+				"@accordproject/markdown-cicero": "0.11.4-20200626055423",
+				"@accordproject/markdown-common": "0.11.4-20200626055423",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			},
 			"dependencies": {
 				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200618182921",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200618182921.tgz",
-					"integrity": "sha512-ukIR1gTK4aE+H9gQ7bR+UKlRM06j+/YOysWRyRgVqd4OPKF8ocF2xBLUq4KUymbBoTL/q+MWZvIjnBRuteY2/Q==",
+					"version": "0.11.4-20200626055423",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
+					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
 					"requires": {
 						"@accordproject/concerto-core": "^0.82.7",
 						"jsome": "2.5.0",
@@ -216,29 +211,29 @@
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.11.4-20200618182921",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.11.4-20200618182921.tgz",
-			"integrity": "sha512-N8q3C8MCtAIu7sKf5SZpifydQqxN7tFmiMx+gDBesU0S7Y1W5ZYkM2FRyz9FbkuXRnruoG4EOjfd0EwpUHk8kA==",
+			"version": "0.11.4-20200626045711",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.11.4-20200626045711.tgz",
+			"integrity": "sha512-aiAXmxQj2Z0uCnHvnFksMGU2S9LdZnDTlciZpjSQaaWgIR1v3KJ6hdrq6OeXKOP5RqY4NrbLYhpQPZmGb7fEWQ==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-pdf": {
-			"version": "0.11.4-20200618182921",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.11.4-20200618182921.tgz",
-			"integrity": "sha512-w3HbzztuhrwKOij4MYA/6Ug575fecUUiK7sL+H1A2RIM86WQ0KJbZf+6e6ITUHgipdpoSkgQDh2g65WWhkkWoA==",
+			"version": "0.11.4-20200626055423",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.11.4-20200626055423.tgz",
+			"integrity": "sha512-Nrk4TsFij5KLXB2f67VaYNAdaukcjnfxLOTV+0LUnx8ihryiIEirPcPpzpu1Z9gYQcwwP0MERXETj5cPxQth9Q==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200618182921",
-				"@accordproject/markdown-common": "0.11.4-20200618182921",
+				"@accordproject/markdown-cicero": "0.11.4-20200626055423",
+				"@accordproject/markdown-common": "0.11.4-20200626055423",
 				"easy-pdf-parser": "0.0.4",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			},
 			"dependencies": {
 				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200618182921",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200618182921.tgz",
-					"integrity": "sha512-ukIR1gTK4aE+H9gQ7bR+UKlRM06j+/YOysWRyRgVqd4OPKF8ocF2xBLUq4KUymbBoTL/q+MWZvIjnBRuteY2/Q==",
+					"version": "0.11.4-20200626055423",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
+					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
 					"requires": {
 						"@accordproject/concerto-core": "^0.82.7",
 						"jsome": "2.5.0",
@@ -250,36 +245,36 @@
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.11.4-20200618182921",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.11.4-20200618182921.tgz",
-			"integrity": "sha512-Od8saapILYWHU7PylIqTb+iSlsmTANH5x32pnzVuuKhnaj+m84FkxNs2RBM1LmpYurmOeFf0RcN7zqNIxVwoIg==",
+			"version": "0.11.4-20200626055423",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.11.4-20200626055423.tgz",
+			"integrity": "sha512-N6GGNhaFJak+JHh3llkk1Clo8iCqKxzQm2olOs4rtqCvLNLqZISjPIh2cFtJIIt/YdP3V3wRj0rIKxCa4tlzdA==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200618182921"
+				"@accordproject/markdown-cicero": "0.11.4-20200626055423"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.11.4-20200618182921",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.11.4-20200618182921.tgz",
-			"integrity": "sha512-nUyqPKADFczOn9YYg9P/S+hvt/HzgJc+WweWS3g3a4JbYZVguN+GrD+UsNiAEV+kBG6psBFW0Eh9PaaH537jkw==",
+			"version": "0.11.4-20200626045711",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.11.4-20200626045711.tgz",
+			"integrity": "sha512-/yHO/JOHe7G1RM3LsUJ2wSiK69HmLKduSJqzntemy07lA0Wyj+2UXHJHtWtmUS9977FP7Dh54RS+VaxoY5sFkA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-cicero": "0.11.4-20200618182921",
-				"@accordproject/markdown-common": "0.11.4-20200618182921",
-				"@accordproject/markdown-it-template": "0.11.4-20200618182921",
+				"@accordproject/markdown-cicero": "0.11.4-20200626045711",
+				"@accordproject/markdown-common": "0.11.4-20200626045711",
+				"@accordproject/markdown-it-template": "0.11.4-20200626045711",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",
 				"uuid": "3.3.2"
 			},
 			"dependencies": {
-				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200618182921",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200618182921.tgz",
-					"integrity": "sha512-ukIR1gTK4aE+H9gQ7bR+UKlRM06j+/YOysWRyRgVqd4OPKF8ocF2xBLUq4KUymbBoTL/q+MWZvIjnBRuteY2/Q==",
+				"@accordproject/markdown-cicero": {
+					"version": "0.11.4-20200626045711",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200626045711.tgz",
+					"integrity": "sha512-F/6eb5lvTy+a0ltUa4xGhFSdlEkp52d8vi3J/r90Rhixql2d5E7XlAZ5m62H4WKnBoQZh1b6ipVWXlX8lsJvuA==",
 					"requires": {
 						"@accordproject/concerto-core": "^0.82.7",
+						"@accordproject/markdown-common": "0.11.4-20200626045711",
 						"jsome": "2.5.0",
-						"markdown-it": "^11.0.0",
 						"winston": "3.2.1",
 						"xmldom": "^0.1.27"
 					}
@@ -287,31 +282,54 @@
 			}
 		},
 		"@accordproject/markdown-transform": {
-			"version": "0.11.4-20200618182921",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.11.4-20200618182921.tgz",
-			"integrity": "sha512-muI7R4QTswrp0gbtXAxujBzmcPolm92TqUUTqPKJ0ojgaYnwmg705QgkxkyHVmhnXdRw/OWNbgnQiQKZuAg9IQ==",
+			"version": "0.11.4-20200626055423",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.11.4-20200626055423.tgz",
+			"integrity": "sha512-sPuRcPR+1/xKdAzo4nl+KHLIMdWwPfkzNd4lBY9IQtsdaK5DTUB0EUJSsdzqjdsbpTtLUbAFsejcM9GWQdYUdw==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-cicero": "0.11.4-20200618182921",
-				"@accordproject/markdown-common": "0.11.4-20200618182921",
-				"@accordproject/markdown-docx": "0.11.4-20200618182921",
-				"@accordproject/markdown-html": "0.11.4-20200618182921",
-				"@accordproject/markdown-pdf": "0.11.4-20200618182921",
-				"@accordproject/markdown-slate": "0.11.4-20200618182921",
-				"@accordproject/markdown-template": "0.11.4-20200618182921",
+				"@accordproject/markdown-cicero": "0.11.4-20200626055423",
+				"@accordproject/markdown-common": "0.11.4-20200626055423",
+				"@accordproject/markdown-docx": "0.11.4-20200626055423",
+				"@accordproject/markdown-html": "0.11.4-20200626055423",
+				"@accordproject/markdown-pdf": "0.11.4-20200626055423",
+				"@accordproject/markdown-slate": "0.11.4-20200626055423",
+				"@accordproject/markdown-template": "0.11.4-20200626055423",
 				"dijkstrajs": "^1.0.1"
 			},
 			"dependencies": {
 				"@accordproject/markdown-common": {
-					"version": "0.11.4-20200618182921",
-					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200618182921.tgz",
-					"integrity": "sha512-ukIR1gTK4aE+H9gQ7bR+UKlRM06j+/YOysWRyRgVqd4OPKF8ocF2xBLUq4KUymbBoTL/q+MWZvIjnBRuteY2/Q==",
+					"version": "0.11.4-20200626055423",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626055423.tgz",
+					"integrity": "sha512-EnqkTsU5OxCRe9+i43WnLWWq9ylisUrqLwOxYb+qe1aluekjF5sAjUwPX/VHbxgUrCGRTJX4/Yfi+JmtCUMd/g==",
 					"requires": {
 						"@accordproject/concerto-core": "^0.82.7",
 						"jsome": "2.5.0",
 						"markdown-it": "^11.0.0",
 						"winston": "3.2.1",
 						"xmldom": "^0.1.27"
+					}
+				},
+				"@accordproject/markdown-it-template": {
+					"version": "0.11.4-20200626055423",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.11.4-20200626055423.tgz",
+					"integrity": "sha512-BUSrYza3Y9rBEIyg47w5cQnE37+f1zVffaZU4n4XHQog9jk0eQcL2gKSNcFkwpGPN3xl+eLb/jvvCdz5a1tWxw==",
+					"requires": {
+						"markdown-it": "^11.0.0"
+					}
+				},
+				"@accordproject/markdown-template": {
+					"version": "0.11.4-20200626055423",
+					"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.11.4-20200626055423.tgz",
+					"integrity": "sha512-OzzFzSokSVb4XqCgFwAES64IgqI9L2173AG9juYUUQ7KDIUzDqSAYoVmpgQgvKVQHTGiOKo7wL99I98QYEv1/g==",
+					"requires": {
+						"@accordproject/concerto-core": "^0.82.7",
+						"@accordproject/markdown-cicero": "0.11.4-20200626055423",
+						"@accordproject/markdown-common": "0.11.4-20200626055423",
+						"@accordproject/markdown-it-template": "0.11.4-20200626055423",
+						"markdown-it": "^11.0.0",
+						"moment-mini": "2.22.1",
+						"parsimmon": "^1.13.0",
+						"uuid": "3.3.2"
 					}
 				}
 			}
@@ -2619,9 +2637,9 @@
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.9.6.tgz",
-			"integrity": "sha512-TcdM3xc7weMrwTawuG3BTjtVE3mQLXUPQ9CxTbSKOrhn3QAcqCJ2fz+IIv25wztzUnhNZat7hr655YJa61F3zg==",
+			"version": "7.10.3",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.3.tgz",
+			"integrity": "sha512-enKvnR/kKFbZFgXYo165wtSA5OeiTlgsnU4jV3vpKRhfWUJjLS6dfVcjIPeRcgJbgEgdgu0I+UyBWqu6c0GumQ==",
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.4"
@@ -7523,11 +7541,6 @@
 				"through": ">=2.2.7 <3"
 			}
 		},
-		"a-sync-waterfall": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-			"integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
-		},
 		"abab": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
@@ -10697,17 +10710,6 @@
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
 		},
-		"commonmark": {
-			"version": "0.29.1",
-			"resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.29.1.tgz",
-			"integrity": "sha512-DafPdNYFXoEhsSiR4O+dJ45UJBfDL4cBTks4B+agKiaWt7qjG0bIhg5xuCE0RqU71ikJcBIf4/sRHh9vYQVF8Q==",
-			"requires": {
-				"entities": "~1.1.1",
-				"mdurl": "~1.0.1",
-				"minimist": "~1.2.0",
-				"string.prototype.repeat": "^0.2.0"
-			}
-		},
 		"compare-func": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
@@ -13389,11 +13391,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
 			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
-		},
-		"discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
 		},
 		"dns-equal": {
 			"version": "1.0.0",
@@ -24240,9 +24237,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+					"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
 				}
 			}
 		},
@@ -26821,11 +26818,6 @@
 			"resolved": "https://registry.npmjs.org/moment-mini/-/moment-mini-2.22.1.tgz",
 			"integrity": "sha512-OUCkHOz7ehtNMYuZjNciXUfwTuz8vmF1MTbAy59ebf+ZBYZO5/tZKuChVWCX+uDo+4idJBpGltNfV8st+HwsGw=="
 		},
-		"moo": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.0.tgz",
-			"integrity": "sha512-AMv6iqhTEd5vT/cQlH6cammKS5ekyHhyqTRKi5zKMWl1RTyFnQ3ohPSBNSm8ySe2wlxSKwDonr9D5ZT44mdO3g=="
-		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -26926,30 +26918,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-		},
-		"nearley": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-			"integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
-			"requires": {
-				"commander": "^2.19.0",
-				"moo": "^0.4.3",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6",
-				"semver": "^5.4.1"
-			},
-			"dependencies": {
-				"moo": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-					"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
 		},
 		"negotiator": {
 			"version": "0.6.2",
@@ -27452,100 +27420,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-		},
-		"nunjucks": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.0.tgz",
-			"integrity": "sha512-YS/qEQ6N7qCnUdm6EoYRBfJUdWNT0PpKbbRnogV2XyXbBm2STIP1O6yrdZHgwMVK7fIYUx7i8+yatEixnXSB1w==",
-			"requires": {
-				"a-sync-waterfall": "^1.0.0",
-				"asap": "^2.0.3",
-				"chokidar": "^2.0.0",
-				"yargs": "^3.32.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"camelcase": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"requires": {
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wrap-ansi": "^2.0.0"
-					}
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-					"requires": {
-						"lcid": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"yargs": {
-					"version": "3.32.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-					"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-					"requires": {
-						"camelcase": "^2.0.1",
-						"cliui": "^3.0.3",
-						"decamelize": "^1.1.1",
-						"os-locale": "^1.4.0",
-						"string-width": "^1.0.1",
-						"window-size": "^0.1.4",
-						"y18n": "^3.2.0"
-					}
-				}
-			}
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -30159,24 +30033,10 @@
 			"resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.2.tgz",
 			"integrity": "sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ=="
 		},
-		"railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
-		},
 		"ramda": {
 			"version": "0.21.0",
 			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
 			"integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU="
-		},
-		"randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"requires": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			}
 		},
 		"randombytes": {
 			"version": "2.1.0",
@@ -36045,11 +35905,6 @@
 				"es-abstract": "^1.17.0-next.1"
 			}
 		},
-		"string.prototype.repeat": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
-			"integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8="
-		},
 		"string.prototype.trimend": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
@@ -39438,11 +39293,6 @@
 					}
 				}
 			}
-		},
-		"window-size": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
 		},
 		"windows-release": {
 			"version": "3.3.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -3,9 +3,9 @@
   "version": "0.93.1",
   "private": true,
   "dependencies": {
-    "@accordproject/cicero-core": "^0.20.10",
-    "@accordproject/markdown-slate": "^0.11.4-20200618165656",
-    "@accordproject/markdown-transform": "^0.11.4-20200618165656",
+    "@accordproject/cicero-core": "^0.20.11-20200626053054",
+    "@accordproject/markdown-slate": "^0.11.4-20200626055423",
+    "@accordproject/markdown-transform": "^0.11.4-20200626055423",
     "@accordproject/ui-components": "0.93.1",
     "@accordproject/ui-concerto": "0.93.1",
     "@accordproject/ui-markdown-editor": "0.93.1",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -3,9 +3,9 @@
   "version": "0.93.1",
   "private": true,
   "dependencies": {
-    "@accordproject/cicero-core": "^0.20.11-20200626053054",
-    "@accordproject/markdown-slate": "^0.11.4-20200626055423",
-    "@accordproject/markdown-transform": "^0.11.4-20200626055423",
+    "@accordproject/cicero-core": "^0.20.11-20200626165149",
+    "@accordproject/markdown-slate": "^0.11.4-20200626164143",
+    "@accordproject/markdown-transform": "^0.11.4-20200626164143",
     "@accordproject/ui-components": "0.93.1",
     "@accordproject/ui-concerto": "0.93.1",
     "@accordproject/ui-markdown-editor": "0.93.1",

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -11,7 +11,6 @@ import { Template, Clause } from '@accordproject/cicero-core';
 import { Editor, Transforms } from 'slate';
 import { uuid } from 'uuidv4';
 
-const templateMarkTransformer = new TemplateMarkTransformer();
 const slateTransformer = new SlateTransformer();
 
 const Wrapper = styled.div`
@@ -55,9 +54,7 @@ This is text. This is *italic* text. This is **bold** text. This is a [link](htt
         .then(async (template) => {
           const clause = new Clause(template);
           clause.parse(template.getMetadata().getSample());
-          const ciceroMark = templateMarkTransformer
-            .draftCiceroMark(clause.getData(), template.getParserManager(), 'contract');
-          const slateValueNew = slateTransformer.fromCiceroMark(ciceroMark);
+          const slateValueNew = clause.draft({ format: 'slate' });
 
           const extraMarkdown = `This is some more text after a clause. Test moving a clause by dragging it or by using the up and down arrows.`;
           const extraText = slateTransformer.fromMarkdown(extraMarkdown);

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -52,32 +52,29 @@ This is text. This is *italic* text. This is **bold** text. This is a [link](htt
   useEffect(() => {
     if (editor) {
       Template.fromUrl(templateUrl)
-      .then(async (template) => {
-        const sample = template.getMetadata().getSample();
-        const templatizedGrammar = template.getParserManager().getTemplatizedGrammar();
-        const modelManager = await template.getModelManager();
-        const data = templateMarkTransformer
-          .dataFromMarkdown(sample, templatizedGrammar, modelManager, 'contract');
-        const ciceroMark = templateMarkTransformer
-          .dataToCiceroMark(data, templatizedGrammar, modelManager, 'contract');
-        const slateValueNew = slateTransformer.fromCiceroMark(ciceroMark);
+        .then(async (template) => {
+          const clause = new Clause(template);
+          clause.parse(template.getMetadata().getSample());
+          const ciceroMark = templateMarkTransformer
+            .draftCiceroMark(clause.getData(), template.getParserManager(), 'contract');
+          const slateValueNew = slateTransformer.fromCiceroMark(ciceroMark);
 
-        const extraMarkdown = `This is some more text after a clause. Test moving a clause by dragging it or by using the up and down arrows.`;
-        const extraText = slateTransformer.fromMarkdown(extraMarkdown);
-        const slateClause = [
-          {
-            children: slateValueNew.document.children,
-            data: {
-              src: templateUrl,
-              name: uuid(),
+          const extraMarkdown = `This is some more text after a clause. Test moving a clause by dragging it or by using the up and down arrows.`;
+          const extraText = slateTransformer.fromMarkdown(extraMarkdown);
+          const slateClause = [
+            {
+              children: slateValueNew.document.children,
+              data: {
+                src: templateUrl,
+                name: uuid(),
+              },
+              object: 'block',
+              type: 'clause',
             },
-            object: 'block',
-            type: 'clause',
-          },
-          ...extraText.document.children
-        ]
-        Transforms.insertNodes(editor, slateClause, { at: Editor.end(editor, [])});
-      });
+            ...extraText.document.children
+          ]
+          Transforms.insertNodes(editor, slateClause, { at: Editor.end(editor, [])});
+        });
     }
   }, [templateUrl, markdownText, editor]);
 

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -54,7 +54,7 @@ This is text. This is *italic* text. This is **bold** text. This is a [link](htt
         .then(async (template) => {
           const clause = new Clause(template);
           clause.parse(template.getMetadata().getSample());
-          const slateValueNew = clause.draft({ format: 'slate' });
+          const slateValueNew = await clause.draft({ format: 'slate' });
 
           const extraMarkdown = `This is some more text after a clause. Test moving a clause by dragging it or by using the up and down arrows.`;
           const extraText = slateTransformer.fromMarkdown(extraMarkdown);

--- a/packages/ui-contract-editor/package.json
+++ b/packages/ui-contract-editor/package.json
@@ -4,9 +4,9 @@
   "private": false,
   "dependencies": {
     "@accordproject/ui-markdown-editor": "0.93.1",
-    "@accordproject/markdown-html": "^0.11.4-20200618165656",
-    "@accordproject/markdown-slate": "^0.11.4-20200618165656",
-    "@accordproject/markdown-transform": "^0.11.4-20200618165656",
+    "@accordproject/markdown-html": "^0.11.4-20200626055423",
+    "@accordproject/markdown-slate": "^0.11.4-20200626055423",
+    "@accordproject/markdown-transform": "^0.11.4-20200626055423",
     "@babel/runtime": "^7.10.3",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",

--- a/packages/ui-contract-editor/package.json
+++ b/packages/ui-contract-editor/package.json
@@ -4,9 +4,9 @@
   "private": false,
   "dependencies": {
     "@accordproject/ui-markdown-editor": "0.93.1",
-    "@accordproject/markdown-html": "^0.11.4-20200626055423",
-    "@accordproject/markdown-slate": "^0.11.4-20200626055423",
-    "@accordproject/markdown-transform": "^0.11.4-20200626055423",
+    "@accordproject/markdown-html": "^0.11.4-20200626164143",
+    "@accordproject/markdown-slate": "^0.11.4-20200626164143",
+    "@accordproject/markdown-transform": "^0.11.4-20200626164143",
     "@babel/runtime": "^7.10.3",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",

--- a/packages/ui-markdown-editor/package.json
+++ b/packages/ui-markdown-editor/package.json
@@ -3,9 +3,9 @@
   "version": "0.93.1",
   "private": false,
   "dependencies": {
-    "@accordproject/markdown-cicero": "^0.11.4-20200618165656",
-    "@accordproject/markdown-html": "^0.11.4-20200618165656",
-    "@accordproject/markdown-slate": "^0.11.4-20200618165656",
+    "@accordproject/markdown-cicero": "^0.11.4-20200626055423",
+    "@accordproject/markdown-html": "^0.11.4-20200626055423",
+    "@accordproject/markdown-slate": "^0.11.4-20200626055423",
     "@babel/runtime": "^7.10.3",
     "image-extensions": "^1.1.0",
     "is-hotkey": "^0.1.6",

--- a/packages/ui-markdown-editor/package.json
+++ b/packages/ui-markdown-editor/package.json
@@ -3,9 +3,9 @@
   "version": "0.93.1",
   "private": false,
   "dependencies": {
-    "@accordproject/markdown-cicero": "^0.11.4-20200626055423",
-    "@accordproject/markdown-html": "^0.11.4-20200626055423",
-    "@accordproject/markdown-slate": "^0.11.4-20200626055423",
+    "@accordproject/markdown-cicero": "^0.11.4-20200626164143",
+    "@accordproject/markdown-html": "^0.11.4-20200626164143",
+    "@accordproject/markdown-slate": "^0.11.4-20200626164143",
     "@babel/runtime": "^7.10.3",
     "image-extensions": "^1.1.0",
     "is-hotkey": "^0.1.6",


### PR DESCRIPTION
# No Issue
Support the new parser from `cicero`

### Changes
- Upgrade `markdown-transform` and `cicero`

### Flags
- My branch should be up to date, not sure what's happening in `package.json`

### Related Issues
- Issue https://github.com/accordproject/cicero/issues/547

### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `master` from `fork:branchname`