### PR TITLE
fix(Library): change onClick to onMouseDown to preserve selection

### DIFF
--- a/packages/ui-components/src/lib/Library/Components/CardActions.js
+++ b/packages/ui-components/src/lib/Library/Components/CardActions.js
@@ -40,13 +40,21 @@ const SecondaryBtn = styled(Btn)`
 const CardActions = props => (
   <ActionsContainer className='ui-components__library-card-actions'>
     <PrimaryBtn
-      onClick={() => props.onPrimaryButtonClick(props.item)}
+    onMouseDown={(e) => {
+      // we use onMouseDown here so as not to lose Slate selection
+      // https://slate-js.slack.com/archives/C1RH7AXSS/p1587510249444700
+      e.preventDefault();
+      props.onPrimaryButtonClick(props.item);
+    }}
       className='ui-components__library-card-primary-btn'
     >
        + Add to contract
     </PrimaryBtn>
     <SecondaryBtn
-      onClick={() => props.onSecondaryButtonClick(props.item)}
+      onMouseDown={(e) => {
+        e.preventDefault();
+        props.onSecondaryButtonClick(props.item);
+      }}
       className='ui-components__library-card-secondary-btn'
     >
       Details


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- fix(Library): change `onClick` to `onMouseDown` to preserve Slate selection when adding a clause from the Library component (see https://slate-js.slack.com/archives/C1RH7AXSS/p1587510249444700)

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Requesting to merge into the v0.93 branch so we can get this bug fix out before finishing the work on the new parser. This fix will also need to be merged into master as well at some point.
