### PR TITLE
fix(ConcertoForm): fix various bugs including DateTime error

### DIFF
--- a/packages/storybook/src/stories/3-ConcertoForm.stories.js
+++ b/packages/storybook/src/stories/3-ConcertoForm.stories.js
@@ -62,7 +62,7 @@ export const Demo = () => {
       json={jsonValue}
       onModelChange={({ types, json }) => {
         setJsonValue(safeStringify(json));
-        return action("model changed")(({ types, json }));
+        return action("model changed")(json);
       }}
       onValueChange={(json) => {
         setJsonValue(safeStringify(json));

--- a/packages/ui-concerto/src/lib/components/concertoForm.js
+++ b/packages/ui-concerto/src/lib/components/concertoForm.js
@@ -90,7 +90,7 @@ class ConcertoForm extends Component {
   }
 
   onFieldValueChange(e, key) {
-    const value = e.type === 'checkbox' ? e.checked : e.value || e.target.value;
+    const value = e.type === 'checkbox' ? e.checked : e.value;
     // eslint-disable-next-line react/no-access-state-in-setstate
     const valueClone = set({ ...this.state.value }, key, value);
     this.setState({ value: valueClone });
@@ -115,7 +115,7 @@ class ConcertoForm extends Component {
       console.error(error.message);
       // Set default values to avoid trying to render a bad model
       // Don't change the JSON, it might be valid once the model file is fixed
-      return {types: []};
+      return { types: [] };
     }
 
     if (types.length === 0) {
@@ -128,7 +128,7 @@ class ConcertoForm extends Component {
       ) {
         fqn = types[0].getFullyQualifiedName();
         json = this.generateJSON(fqn);
-        return {types, json};
+        return { types, json };
       }
       json = this.generateJSON(this.props.type);
     } catch (err) {

--- a/packages/ui-concerto/src/lib/components/fields.js
+++ b/packages/ui-concerto/src/lib/components/fields.js
@@ -75,18 +75,21 @@ export const ConcertoDateTime = ({
   onFieldValueChange,
   skipLabel,
   type,
-}) => (
+}) => {
+  const date = Date.parse(value) ? value : new Date().toISOString();
+  return (
   <Form.Field required={required}>
     <ConcertoLabel skip={skipLabel} name={field.getName()} />
     <Input
       type={type}
       readOnly={readOnly}
-      value={new Date(value).toISOString().slice(0, 19)}
+      value={date.slice(0, 16)}
       onChange={(e, data) => onFieldValueChange(data, id)}
       key={id}
     />
   </Form.Field>
-);
+  );
+};
 
 export const ConcertoArray = ({
   id,

--- a/packages/ui-concerto/src/lib/reactformvisitor.js
+++ b/packages/ui-concerto/src/lib/reactformvisitor.js
@@ -296,12 +296,12 @@ class ReactFormVisitor {
     const value = get(parameters.json, key);
     if (field.isPrimitive()) {
       if (field.getType() === 'Boolean') {
-        return <ConcertoCheckbox {...props} id={key} value={value} />;
+        return <ConcertoCheckbox {...props} id={key} key={key} value={value} />;
       }
       if (toFieldType(field.getType()) === 'datetime-local') {
-        return <ConcertoDateTime {...props} id={key} value={value} />;
+        return <ConcertoDateTime {...props} id={key} key={key} value={value} />;
       }
-      return <ConcertoInput {...props} id={key} value={value} />;
+      return <ConcertoInput {...props} id={key} key={key} value={value} />;
     }
     let type = parameters.modelManager.getType(
       field.getFullyQualifiedTypeName()
@@ -365,7 +365,7 @@ class ReactFormVisitor {
               const key = toPath(stack);
               const value = get(parameters.json, key);
               const arrayComponent = (
-                <ConcertoArrayElement {...commonProps} index={index}>
+                <ConcertoArrayElement key={key} {...commonProps} index={index}>
                   <ConcertoInput {...commonProps} id={key} value={value} />
                 </ConcertoArrayElement>
               );


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #131 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Fixes DateTime error that caused crash. The value supplied by the form on change is already an ISO string, so we shouldn't use `toISOString` on it, unless there is no value (ie. we just changed the model to be DateTime), then use `new Date().toISOString()` to get the current date/time. Slice on the string was changed from `(0,19)` to `(0,16)` to exclude seconds.
- Fixes issue where empty strings were not allowed as values because `e.value` on an empty string is falsey and `e.target.value` would throw an error in the console.
- Adds keys to iterable React components where necessary
- Removed `types` from onModelChange storybook action because it throws an error in the console and does not log as a storybook action.

### Flags
- I'll make this same PR into master after this one goes in, but I wanted to be able to get this bug fix into the v0.93 branch to be available to use now.
