### PR TITLE
fix(ConcertoForm): use DateTime format consistent with Cicero and fix…

### DIFF
--- a/packages/storybook/src/stories/3-ConcertoForm.stories.js
+++ b/packages/storybook/src/stories/3-ConcertoForm.stories.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { text, boolean, object } from '@storybook/addon-knobs';
 import { ConcertoForm } from '@accordproject/ui-concerto';
+import 'semantic-ui-css/semantic.min.css';
 
 export default {
   title: 'Concerto Form',

--- a/packages/ui-concerto/src/lib/components/fields.js
+++ b/packages/ui-concerto/src/lib/components/fields.js
@@ -82,8 +82,9 @@ export const ConcertoDateTime = ({
       readOnly={readOnly}
       value={value}
       onChange={(e, data) => onFieldValueChange(data, id)}
-      dateTimeFormat={'YYYY-MM-DD HH:mm'}
+      dateTimeFormat={'YYYY-MM-DDTHH:mm:ss.sssZ'}
       key={id}
+      animation='none'
     />
   </Form.Field>
 );


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

### Changes
- Few more fixes related to #138 
- Uses DateTime format consistent with Cicero
- Uses `animation='none'` to circumvent [this issue](https://github.com/arfedulov/semantic-ui-calendar-react/issues/152) with semantic ui