### PR TITLE
feat(ui-markdown-editor): match style of dropdown headings - i103

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7489,23 +7489,6 @@
 						"which": "^2.0.1"
 					}
 				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"detect-port-alt": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-					"integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
-					"requires": {
-						"address": "^1.0.1",
-						"debug": "^2.6.0"
-					}
-				},
 				"ejs": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7489,23 +7489,6 @@
 						"which": "^2.0.1"
 					}
 				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"detect-port-alt": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-					"integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
-					"requires": {
-						"address": "^1.0.1",
-						"debug": "^2.6.0"
-					}
-				},
 				"ejs": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.3.tgz",
@@ -16105,6 +16088,25 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
 			"integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+			"requires": {
+				"address": "^1.0.1",
+				"debug": "^2.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"detect-port-alt": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
+			"integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
 			"requires": {
 				"address": "^1.0.1",
 				"debug": "^2.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7489,6 +7489,23 @@
 						"which": "^2.0.1"
 					}
 				},
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"detect-port-alt": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
+					"integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
+					"requires": {
+						"address": "^1.0.1",
+						"debug": "^2.6.0"
+					}
+				},
 				"ejs": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.3.tgz",

--- a/packages/storybook/src/stories/1-MarkdownEditor.stories.js
+++ b/packages/storybook/src/stories/1-MarkdownEditor.stories.js
@@ -63,8 +63,8 @@ And this is <variable>an HTML inline</variable>.
 ## H2
 ### H3
 #### H4
-#### H5
-##### H6
+##### H5
+###### H6
 
 Fin.
 `;

--- a/packages/storybook/src/stories/__snapshots__/1-MarkdownEditor.test.js.snap
+++ b/packages/storybook/src/stories/__snapshots__/1-MarkdownEditor.test.js.snap
@@ -527,9 +527,17 @@ exports[`Markdown Editor Storyshots Markdown Editor Demo 1`] = `
     suppressContentEditableWarning={true}
   >
     <h1
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="My-Heading"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "25px",
+          "fontWeight": "bold",
+          "lineHeight": "23px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -726,9 +734,17 @@ exports[`Markdown Editor Storyshots Markdown Editor Demo 1`] = `
       </span>
     </p>
     <h2
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="Breaks"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "20px",
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -976,9 +992,17 @@ exports[`Markdown Editor Storyshots Markdown Editor Demo 1`] = `
       </p>
     </blockquote>
     <h2
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="Heading-Two"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "20px",
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -1222,9 +1246,17 @@ code
       </li>
     </ul>
     <h3
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="Sub-heading"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "16px",
+          "fontWeight": "bold",
+          "lineHeight": "16px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -1367,9 +1399,17 @@ This is an html block.
       </span>
     </p>
     <h1
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="H1"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "25px",
+          "fontWeight": "bold",
+          "lineHeight": "23px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -1386,9 +1426,17 @@ This is an html block.
       </span>
     </h1>
     <h2
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="H2"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "20px",
+          "fontWeight": "bold",
+          "lineHeight": "20px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -1405,9 +1453,17 @@ This is an html block.
       </span>
     </h2>
     <h3
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="H3"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "16px",
+          "fontWeight": "bold",
+          "lineHeight": "16px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -1424,9 +1480,17 @@ This is an html block.
       </span>
     </h3>
     <h4
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="H4"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "14px",
+          "fontWeight": "bold",
+          "lineHeight": "14px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -1442,10 +1506,18 @@ This is an html block.
         </span>
       </span>
     </h4>
-    <h4
-      className="sc-AxiKw cBJqoo"
+    <h5
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="H5"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "12px",
+          "fontWeight": "bold",
+          "lineHeight": "12px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -1460,11 +1532,19 @@ This is an html block.
           </span>
         </span>
       </span>
-    </h4>
-    <h5
-      className="sc-AxiKw cBJqoo"
+    </h5>
+    <h6
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="H6"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "10px",
+          "fontWeight": "bold",
+          "lineHeight": "10px",
+        }
+      }
     >
       <span
         data-slate-node="text"
@@ -1479,7 +1559,7 @@ This is an html block.
           </span>
         </span>
       </span>
-    </h5>
+    </h6>
     <p
       data-slate-node="element"
     >

--- a/packages/storybook/src/stories/__snapshots__/4-ContractEditor.test.js.snap
+++ b/packages/storybook/src/stories/__snapshots__/4-ContractEditor.test.js.snap
@@ -523,9 +523,17 @@ exports[`Contract Editor Storyshots Contract Editor Contract Editor 1`] = `
     suppressContentEditableWarning={true}
   >
     <h1
-      className="sc-AxiKw cBJqoo"
+      className="sc-AxiKw Osaca"
       data-slate-node="element"
       id="Heading-One"
+      style={
+        Object {
+          "color": "#122330",
+          "fontSize": "25px",
+          "fontWeight": "bold",
+          "lineHeight": "23px",
+        }
+      }
     >
       <span
         data-slate-node="text"

--- a/packages/ui-markdown-editor/src/lib/components/Node/Heading.js
+++ b/packages/ui-markdown-editor/src/lib/components/Node/Heading.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import * as SCHEMA from '../../utilities/schema';
 
 const Heading = styled.div`
-  font-family: serif;
+  font-family: inherit;
 `;
 
 Heading.propTypes = {

--- a/packages/ui-markdown-editor/src/lib/components/index.js
+++ b/packages/ui-markdown-editor/src/lib/components/index.js
@@ -9,6 +9,14 @@ import {
   CODE_BLOCK, HTML_BLOCK, BLOCK_QUOTE, UL_LIST, OL_LIST, LIST_ITEM,
   HTML_INLINE, SOFTBREAK, LINEBREAK, HEADINGS
 } from '../utilities/schema';
+import {
+  DROPDOWN_STYLE_H1,
+  DROPDOWN_STYLE_H2,
+  DROPDOWN_STYLE_H3,
+  DROPDOWN_STYLE_H4,
+  DROPDOWN_STYLE_H5,
+  DROPDOWN_STYLE_H6
+} from '../utilities/constants';
 import generateId from '../utilities/generateId';
 
 const Element = (props) => {
@@ -19,12 +27,12 @@ const Element = (props) => {
   const headingId = HEADINGS.includes(type) ? generateId(element) : null;
   const baseElementRenderer = {
     [PARAGRAPH]: () => (<p {...attributes}>{children}</p>),
-    [H1]: () => (<Heading id={headingId} as="h1" {...attributes}>{children}</Heading>),
-    [H2]: () => (<Heading id={headingId} as="h2" {...attributes}>{children}</Heading>),
-    [H3]: () => (<Heading id={headingId} as="h3" {...attributes}>{children}</Heading>),
-    [H4]: () => (<Heading id={headingId} as="h4" {...attributes}>{children}</Heading>),
-    [H5]: () => (<Heading id={headingId} as="h5" {...attributes}>{children}</Heading>),
-    [H6]: () => (<Heading id={headingId} as="h6" {...attributes}>{children}</Heading>),
+    [H1]: () => (<Heading id={headingId} as="h1" style={DROPDOWN_STYLE_H1} {...attributes}>{children}</Heading>),
+    [H2]: () => (<Heading id={headingId} as="h2" style={DROPDOWN_STYLE_H2} {...attributes}>{children}</Heading>),
+    [H3]: () => (<Heading id={headingId} as="h3" style={DROPDOWN_STYLE_H3} {...attributes}>{children}</Heading>),
+    [H4]: () => (<Heading id={headingId} as="h4" style={DROPDOWN_STYLE_H4} {...attributes}>{children}</Heading>),
+    [H5]: () => (<Heading id={headingId} as="h5" style={DROPDOWN_STYLE_H5} {...attributes}>{children}</Heading>),
+    [H6]: () => (<Heading id={headingId} as="h6" style={DROPDOWN_STYLE_H6} {...attributes}>{children}</Heading>),
     [SOFTBREAK]: () => (<span className={SOFTBREAK} {...attributes}> {children}</span>),
     [LINEBREAK]: () => (<br className={LINEBREAK} {...attributes} />),
     [LINK]: () => (<a {...attributes} href={data.href}>{children}</a>),

--- a/packages/ui-markdown-editor/src/lib/utilities/constants.js
+++ b/packages/ui-markdown-editor/src/lib/utilities/constants.js
@@ -16,7 +16,7 @@ export const BUTTON_COLORS = {
 export const BUTTON_ACTIVE = {
   background: BUTTON_COLORS.BACKGROUND_ACTIVE,
   symbol: BUTTON_COLORS.SYMBOL_ACTIVE
-}
+};
 
 export const BLOCK_STYLE = {
   paragraph: MISC_CONSTANTS.DROPDOWN_NORMAL,
@@ -51,6 +51,27 @@ export const DROPDOWN_STYLE_H2 = {
 export const DROPDOWN_STYLE_H3 = {
   fontSize: '16px',
   lineHeight: '16px',
+  fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
+  color: MISC_CONSTANTS.DROPDOWN_COLOR,
+};
+
+export const DROPDOWN_STYLE_H4 = {
+  fontSize: '14px',
+  lineHeight: '14px',
+  fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
+  color: MISC_CONSTANTS.DROPDOWN_COLOR,
+};
+
+export const DROPDOWN_STYLE_H5 = {
+  fontSize: '12px',
+  lineHeight: '12px',
+  fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
+  color: MISC_CONSTANTS.DROPDOWN_COLOR,
+};
+
+export const DROPDOWN_STYLE_H6 = {
+  fontSize: '10px',
+  lineHeight: '10px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
   color: MISC_CONSTANTS.DROPDOWN_COLOR,
 };


### PR DESCRIPTION
# Issue #103 

### Changes
- Match the style of headings in the contents to that of the preview headings in the dropdown toolbar
  - (Markdown Editor Heading.js) Removed 'serif' as default font-family for headings in dropdown toolbar for in favour of inheriting common base style
  - New dropdown style constants added for H4 to H6
  - BaseElementRenderer to use dropdown style constants 
  - Fixed Markdown Editor storybook demo to use correct tags from h1 to h6
- Update snapshots to reflect new styles from markdown editor
  - Updated Contract Editor snapshot (style attribute of id="Heading-One")
  - Updated Markdown Editor snapshot (headings styles)

### Flags
- This change contains new base snapshots for tests

### Related Issues
#103 