### PR TITLE
feat(*): init optional variable support - I145

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.20.11-20200626165149",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.20.11-20200626165149.tgz",
-			"integrity": "sha512-TNwNLXXrwBtAsZD9CPSwXwo2yUbHLUkhetNdrUMluoz6vKkrScm5JIJl7IVOfzHVifORgsplkw51LGqaH7axTg==",
+			"version": "0.20.11-20200707140253",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.20.11-20200707140253.tgz",
+			"integrity": "sha512-HDMej4zF2/fV7defchli7TU55IuhLD2UJBbOt8csLRNH6osQfAfcc+0y1/iet9AIDDIyg0AMb/JmpV3v0euQ6w==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.7",
 				"@accordproject/ergo-compiler": "0.20.10",
 				"@accordproject/ergo-engine": "0.20.10",
-				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
-				"@accordproject/markdown-common": "0.11.4-20200626164143",
-				"@accordproject/markdown-html": "0.11.4-20200626164143",
-				"@accordproject/markdown-slate": "0.11.4-20200626164143",
-				"@accordproject/markdown-template": "0.11.4-20200626164143",
+				"@accordproject/markdown-cicero": "0.11.4-20200707133347",
+				"@accordproject/markdown-common": "0.11.4-20200707133347",
+				"@accordproject/markdown-html": "0.11.4-20200707133347",
+				"@accordproject/markdown-slate": "0.11.4-20200707133347",
+				"@accordproject/markdown-template": "0.11.4-20200707133347",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
@@ -100,21 +100,21 @@
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-z/7nXC45GfXjC1FTuq7dLr6qczkSlyHDaG5Y69/yyvQO9dcgcHdGfxaDsL3GeyVESCyiFkv0DTwm+ttWjtjTAw==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-tuw4JAUhVNWWgaJmDlOxaV405PK21Ulf4W8AECuwBe2tcwQB6g06/aq9jAXbQbeVKiVAIYaZvz7tkJxIEEndBA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-common": "0.11.4-20200626164143",
+				"@accordproject/markdown-common": "0.11.4-20200707133347",
 				"jsome": "2.5.0",
 				"winston": "3.2.1",
 				"xmldom": "^0.1.27"
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-kxYB3VSAHA3SVCoRBmFILjzwj2fwUFGd0Y3uHs4POvUlElrvh3kedZ/lTtQqJOQtnTCiSDIbaD/tpr2brIcAgA==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-0ku7fW/LELDe5PBDqQXals0E96v/PIFoRGfLVnIXvFt2+48xL43oMEwtjmKPEoLxElqM6Y6CQWSDBenGzKzNlw==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
 				"jsome": "2.5.0",
@@ -124,63 +124,64 @@
 			}
 		},
 		"@accordproject/markdown-docx": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-b20qvnor3SSoesM1oxEZCbZYm0ltRVkYuuB0YaY6prtdR1R0rAtpFuCmwOy3jdAo8DIAvaTcjdtQWMyAJDMNXA==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-nZzl/aH1AHxpZrqLLICRX+LTudRonB7xibIsKABanoRVFT66y1KSV3WFy1HTIc/qHRUkU8oqoNiS1CTVPh1ENg==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
-				"@accordproject/markdown-common": "0.11.4-20200626164143",
+				"@accordproject/markdown-cicero": "0.11.4-20200707133347",
+				"@accordproject/markdown-common": "0.11.4-20200707133347",
 				"mammoth": "^1.4.9"
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-6Tq8g+0vOmP7ybLmbty/STU6CeF71ixIag2iWxiYzZZPSJlbMLdpjn4RtDfAAGU/2TlyDR5O8Ns16Qb32X1IGw==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-fo6PDtEtVVTZFS0xsKPpxyngwNF9lwldCtOqOgjRMGe9WPDGqktBV2sogqir+kKAIY+U8RIv+B6ah3MnrzHd0g==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
-				"@accordproject/markdown-common": "0.11.4-20200626164143",
+				"@accordproject/markdown-cicero": "0.11.4-20200707133347",
+				"@accordproject/markdown-common": "0.11.4-20200707133347",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-BnkHUZr4xcs9V4OGv6E/bgoq82sUQW/UBkELkD5SModK3U/XhIcJpZUThQ8PwFS+M+1JKI7yOSItapK2ZMfdIQ==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-441rXveOYuBVTmPJBx4OQDGC78dfNR1SvAcVVvqy588MFSnIdlYibBxQJ4f+f9aQQxhflEj+AmCZ+rgx7HfKoQ==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-pdf": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-EXR4CUj8iEkKIywUQOH7vV9POTJfSg4yqXolTfFmeeMmWAEhHjLOQhvarmn67VhPHtFmFggaRtCuGIWAdhUWXg==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-jcM4F7XkC5/E/PnaDzPZQA1Sovs2jgKxiv5Gti8MLoK4a/ZeKA8ITAgB07kNHSpD8sBoujt0pfUNleyxc9UHig==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
-				"@accordproject/markdown-common": "0.11.4-20200626164143",
+				"@accordproject/markdown-cicero": "0.11.4-20200707133347",
+				"@accordproject/markdown-common": "0.11.4-20200707133347",
 				"easy-pdf-parser": "0.0.4",
 				"jsdom": "^15.2.1",
+				"pdfmake": "0.1.66",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-stjyiy6i+6UNWf1F7rKOfqp1/TxfU3WYIDm+FViXbqPvAlLIatyh1CwmqqlmTvMmqx9hiI88sqAjNSSiMMT78w==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-g7Em/NUyfSMtPNr32ER5chP4uAtyeLxMUS41N8EXdoIdBSd6JMJIbIJW2zYhf6iDQXo4w+0Rb9yVUjcOr8xypA==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.11.4-20200626164143"
+				"@accordproject/markdown-cicero": "0.11.4-20200707133347"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-ZKCFzC4dhAU8apKU8ajxfvdI+OUdAjQTcbh6A0GJ9YIu0PB5CucS/o0jxn0SK0pyRJHkHNd0ytaj7UOguJo7vg==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-yTieF2veh/1IRXxS0Hlh4KnWTiYyjAVE3yMWUzhhJ9M0wmezEkFM/c2m38rahZFAPcR8INKetmpvD3CS+sQTYA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
-				"@accordproject/markdown-common": "0.11.4-20200626164143",
-				"@accordproject/markdown-it-template": "0.11.4-20200626164143",
+				"@accordproject/markdown-cicero": "0.11.4-20200707133347",
+				"@accordproject/markdown-common": "0.11.4-20200707133347",
+				"@accordproject/markdown-it-template": "0.11.4-20200707133347",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",
@@ -188,18 +189,18 @@
 			}
 		},
 		"@accordproject/markdown-transform": {
-			"version": "0.11.4-20200626164143",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.11.4-20200626164143.tgz",
-			"integrity": "sha512-0sn0Ova3SdDfWM2PulJJjo0vCqqwRv2K0/f97DpkSAWJ20OkOi+tZWsmbGXVUWWh1+vWXTo7zFoBRHvFP3JwFQ==",
+			"version": "0.11.4-20200707133347",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.11.4-20200707133347.tgz",
+			"integrity": "sha512-byo/HJpNLb6u1iJExnfMIURVwcBzOcF1wrageZEmyLOBacIeA85SMZ25fM62WaA81otpPuv0At0VmmXd7EbmFw==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.7",
-				"@accordproject/markdown-cicero": "0.11.4-20200626164143",
-				"@accordproject/markdown-common": "0.11.4-20200626164143",
-				"@accordproject/markdown-docx": "0.11.4-20200626164143",
-				"@accordproject/markdown-html": "0.11.4-20200626164143",
-				"@accordproject/markdown-pdf": "0.11.4-20200626164143",
-				"@accordproject/markdown-slate": "0.11.4-20200626164143",
-				"@accordproject/markdown-template": "0.11.4-20200626164143",
+				"@accordproject/markdown-cicero": "0.11.4-20200707133347",
+				"@accordproject/markdown-common": "0.11.4-20200707133347",
+				"@accordproject/markdown-docx": "0.11.4-20200707133347",
+				"@accordproject/markdown-html": "0.11.4-20200707133347",
+				"@accordproject/markdown-pdf": "0.11.4-20200707133347",
+				"@accordproject/markdown-slate": "0.11.4-20200707133347",
+				"@accordproject/markdown-template": "0.11.4-20200707133347",
 				"dijkstrajs": "^1.0.1"
 			}
 		},
@@ -2575,9 +2576,9 @@
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.10.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.3.tgz",
-			"integrity": "sha512-enKvnR/kKFbZFgXYo165wtSA5OeiTlgsnU4jV3vpKRhfWUJjLS6dfVcjIPeRcgJbgEgdgu0I+UyBWqu6c0GumQ==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.4.tgz",
+			"integrity": "sha512-9sArmpZDQsnR1yyAcU51DxQrntWxt0LUKjPp3pIyo7kVLfaqKt8muppcT87QmFkXV5H50qXAF8JWOjk0jaXRYA==",
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.4"
@@ -10242,6 +10243,28 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
 			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
 		},
+		"acorn-node": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+			"integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+			"requires": {
+				"acorn": "^7.0.0",
+				"acorn-walk": "^7.0.0",
+				"xtend": "^4.0.2"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+					"integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+				},
+				"acorn-walk": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+					"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+				}
+			}
+		},
 		"acorn-walk": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
@@ -10421,6 +10444,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
 			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"optional": true
 		},
 		"ansi-align": {
 			"version": "3.0.0",
@@ -10655,6 +10684,11 @@
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
+		"array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -10851,6 +10885,53 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"ast-transform": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/ast-transform/-/ast-transform-0.0.0.tgz",
+			"integrity": "sha1-dJRAWIh9goPhidlUYAlHvJj+AGI=",
+			"requires": {
+				"escodegen": "~1.2.0",
+				"esprima": "~1.0.4",
+				"through": "~2.3.4"
+			},
+			"dependencies": {
+				"escodegen": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.2.0.tgz",
+					"integrity": "sha1-Cd55Z3kcyVi3+Jot220jRRrzJ+E=",
+					"requires": {
+						"esprima": "~1.0.4",
+						"estraverse": "~1.5.0",
+						"esutils": "~1.0.0",
+						"source-map": "~0.1.30"
+					}
+				},
+				"esprima": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+					"integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+				},
+				"estraverse": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+					"integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
+				},
+				"esutils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+					"integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
+				},
+				"source-map": {
+					"version": "0.1.43",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+					"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+					"optional": true,
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				}
+			}
 		},
 		"ast-types": {
 			"version": "0.12.4",
@@ -12502,10 +12583,29 @@
 				}
 			}
 		},
+		"brfs": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brfs/-/brfs-2.0.2.tgz",
+			"integrity": "sha512-IrFjVtwu4eTJZyu8w/V2gxU7iLTtcHih67sgEdzrhjLBMHp2uYefUBfdM4k2UvcuWMgV7PQDZHSLeNWnLFKWVQ==",
+			"requires": {
+				"quote-stream": "^1.0.1",
+				"resolve": "^1.1.5",
+				"static-module": "^3.0.2",
+				"through2": "^2.0.0"
+			}
+		},
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"brotli": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
+			"integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
+			"requires": {
+				"base64-js": "^1.1.2"
+			}
 		},
 		"brotli-size": {
 			"version": "4.0.0",
@@ -12577,6 +12677,23 @@
 				"level-filesystem": "^1.0.1",
 				"level-js": "^2.1.3",
 				"levelup": "^0.18.2"
+			}
+		},
+		"browserify-optional": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-optional/-/browserify-optional-1.0.1.tgz",
+			"integrity": "sha1-HhNyLP3g2F8SFnbCpyztUzoBiGk=",
+			"requires": {
+				"ast-transform": "0.0.0",
+				"ast-types": "^0.7.0",
+				"browser-resolve": "^1.8.1"
+			},
+			"dependencies": {
+				"ast-types": {
+					"version": "0.7.8",
+					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+					"integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk="
+				}
 			}
 		},
 		"browserify-rsa": {
@@ -12687,6 +12804,11 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
 			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+		},
+		"buffer-equal": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+			"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
 		},
 		"buffer-es6": {
 			"version": "4.9.3",
@@ -15172,6 +15294,11 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"crypto-js": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+			"integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+		},
 		"crypto-random-string": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -15679,6 +15806,11 @@
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
+		},
+		"dash-ast": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+			"integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA=="
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -16241,6 +16373,11 @@
 				"asap": "^2.0.0",
 				"wrappy": "1"
 			}
+		},
+		"dfa": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+			"integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
 		},
 		"diagnostics": {
 			"version": "1.1.1",
@@ -17143,6 +17280,43 @@
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"requires": {
+				"readable-stream": "^2.0.2"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
+			}
+		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -17560,6 +17734,19 @@
 				"es6-symbol": "^3.1.1"
 			}
 		},
+		"es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-set": "~0.1.5",
+				"es6-symbol": "~3.1.1",
+				"event-emitter": "~0.3.5"
+			}
+		},
 		"es6-promise": {
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -17573,6 +17760,29 @@
 			"dev": true,
 			"requires": {
 				"es6-promise": "^4.0.3"
+			}
+		},
+		"es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "~0.3.5"
+			},
+			"dependencies": {
+				"es6-symbol": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+					"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+					"requires": {
+						"d": "1",
+						"es5-ext": "~0.10.14"
+					}
+				}
 			}
 		},
 		"es6-shim": {
@@ -18268,6 +18478,11 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
 		},
+		"estree-is-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/estree-is-function/-/estree-is-function-1.0.0.tgz",
+			"integrity": "sha512-nSCWn1jkSq2QAtkaVLJZY2ezwcFO161HVc174zL1KPW3RJ+O6C3eJb8Nx7OXzvhoEv+nLgSR1g71oWUHUDTrJA=="
+		},
 		"estree-walker": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
@@ -18289,6 +18504,15 @@
 			"integrity": "sha512-npGsebJejyjMRnLdFu+T/97dnigqIU0Ov3IGrZ8ygd1v7RL1vGkEKtvyWZobqUH1AQgKlg0Yqqe2BtMA9/QZLw==",
 			"requires": {
 				"require-like": ">= 0.1.1"
+			}
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"event-source-polyfill": {
@@ -19069,6 +19293,45 @@
 					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"requires": {
 						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"fontkit": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.8.1.tgz",
+			"integrity": "sha512-BsNCjDoYRxmNWFdAuK1y9bQt+igIxGtTC9u/jSFjR9MKhmI00rP1fwSvERt+5ddE82544l0XH5mzXozQVUy2Tw==",
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"brfs": "^2.0.0",
+				"brotli": "^1.2.0",
+				"browserify-optional": "^1.0.1",
+				"clone": "^1.0.4",
+				"deep-equal": "^1.0.0",
+				"dfa": "^1.2.0",
+				"restructure": "^0.5.3",
+				"tiny-inflate": "^1.0.2",
+				"unicode-properties": "^1.2.2",
+				"unicode-trie": "^0.3.0"
+			},
+			"dependencies": {
+				"clone": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+				},
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+				},
+				"unicode-trie": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz",
+					"integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
+					"requires": {
+						"pako": "^0.2.5",
+						"tiny-inflate": "^1.0.0"
 					}
 				}
 			}
@@ -22473,6 +22736,11 @@
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
 			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+		},
+		"get-assigned-identifiers": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+			"integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="
 		},
 		"get-caller-file": {
 			"version": "1.0.3",
@@ -30438,6 +30706,23 @@
 				"immediate": "~3.0.5"
 			}
 		},
+		"linebreak": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.0.2.tgz",
+			"integrity": "sha512-bJwSRsJeAmaZYnkcwl5sCQNfSDAhBuXxb6L27tb+qkBRtUQSSTUa5bcgCPD6hFEkRNlpWHfK7nFMmcANU7ZP1w==",
+			"requires": {
+				"base64-js": "0.0.8",
+				"brfs": "^2.0.2",
+				"unicode-trie": "^1.0.0"
+			},
+			"dependencies": {
+				"base64-js": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+					"integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+				}
+			}
+		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -33894,23 +34179,19 @@
 			"dependencies": {
 				"async": {
 					"version": "3.2.0",
-					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/async/-/async-3.2.0.tgz",
-					"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+					"bundled": true
 				},
 				"lodash": {
 					"version": "4.17.15",
-					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+					"bundled": true
 				},
 				"minimist": {
 					"version": "0.0.10",
-					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+					"bundled": true
 				},
 				"optimist": {
 					"version": "0.6.1",
-					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/optimist/-/optimist-0.6.1.tgz",
-					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+					"bundled": true,
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -33918,13 +34199,43 @@
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+					"bundled": true
 				},
 				"xmldom": {
 					"version": "0.3.0",
-					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/xmldom/-/xmldom-0.3.0.tgz",
-					"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
+					"bundled": true
+				}
+			}
+		},
+		"pdfkit": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.11.0.tgz",
+			"integrity": "sha512-1s9gaumXkYxcVF1iRtSmLiISF2r4nHtsTgpwXiK8Swe+xwk/1pm8FJjYqN7L3x13NsWnGyUFntWcO8vfqq+wwA==",
+			"requires": {
+				"crypto-js": "^3.1.9-1",
+				"fontkit": "^1.8.0",
+				"linebreak": "^1.0.2",
+				"png-js": "^1.0.0"
+			}
+		},
+		"pdfmake": {
+			"version": "0.1.66",
+			"resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.1.66.tgz",
+			"integrity": "sha512-NFR1hn5d4NDPOGFY2/jCt6eRLO2x2BFtr/vdl321DjlPYX9DxGwDAgCnNfTfh96lhewHDuAD8YU4X2l0kjnB2Q==",
+			"requires": {
+				"iconv-lite": "^0.6.0",
+				"linebreak": "^1.0.2",
+				"pdfkit": "^0.11.0",
+				"svg-to-pdfkit": "^0.1.8"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.1.tgz",
+					"integrity": "sha512-Gjcihg3Bi6PI+5V7JlqWmXyVDyX5UQuwulJcbb3btuSoXIoGUy8zwJpRIOpRSzHz0IVnsT2FkceLlM8mm72d3w==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
+					}
 				}
 			}
 		},
@@ -34051,6 +34362,11 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"png-js": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+			"integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
 		},
 		"pnp-webpack-plugin": {
 			"version": "1.5.0",
@@ -35677,6 +35993,16 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+		},
+		"quote-stream": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+			"integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
+			"requires": {
+				"buffer-equal": "0.0.1",
+				"minimist": "^1.1.3",
+				"through2": "^2.0.0"
+			}
 		},
 		"raf": {
 			"version": "3.4.1",
@@ -40381,6 +40707,14 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"restructure": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/restructure/-/restructure-0.5.4.tgz",
+			"integrity": "sha1-9U591WNZD7NP1r9Vh2EJrsyyjeg=",
+			"requires": {
+				"browserify-optional": "^1.0.0"
+			}
+		},
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -41024,6 +41358,20 @@
 				"ajv-keywords": "^3.1.0"
 			}
 		},
+		"scope-analyzer": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/scope-analyzer/-/scope-analyzer-2.1.1.tgz",
+			"integrity": "sha512-azEAihtQ9mEyZGhfgTJy3IbOWEzeOrYbg7NcYEshPKnKd+LZmC3TNd5dmDxbLBsTG/JVWmCp+vDJ03vJjeXMHg==",
+			"requires": {
+				"array-from": "^2.1.1",
+				"dash-ast": "^1.0.0",
+				"es6-map": "^0.1.5",
+				"es6-set": "^0.1.5",
+				"es6-symbol": "^3.1.1",
+				"estree-is-function": "^1.0.0",
+				"get-assigned-identifiers": "^1.1.0"
+			}
+		},
 		"scroll-behavior": {
 			"version": "0.9.12",
 			"resolved": "https://registry.npmjs.org/scroll-behavior/-/scroll-behavior-0.9.12.tgz",
@@ -41392,6 +41740,11 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/shallow-compare/-/shallow-compare-1.2.2.tgz",
 			"integrity": "sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg=="
+		},
+		"shallow-copy": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+			"integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
 		},
 		"shallow-equal": {
 			"version": "1.2.1",
@@ -42181,6 +42534,14 @@
 			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
 			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
 		},
+		"static-eval": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+			"integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
+			"requires": {
+				"escodegen": "^1.11.1"
+			}
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -42196,6 +42557,77 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
 						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"static-module": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.4.tgz",
+			"integrity": "sha512-gb0v0rrgpBkifXCa3yZXxqVmXDVE+ETXj6YlC/jt5VzOnGXR2C15+++eXuMDUYsePnbhf+lwW0pE1UXyOLtGCw==",
+			"requires": {
+				"acorn-node": "^1.3.0",
+				"concat-stream": "~1.6.0",
+				"convert-source-map": "^1.5.1",
+				"duplexer2": "~0.1.4",
+				"escodegen": "^1.11.1",
+				"has": "^1.0.1",
+				"magic-string": "0.25.1",
+				"merge-source-map": "1.0.4",
+				"object-inspect": "^1.6.0",
+				"readable-stream": "~2.3.3",
+				"scope-analyzer": "^2.0.1",
+				"shallow-copy": "~0.0.1",
+				"static-eval": "^2.0.5",
+				"through2": "~2.0.3"
+			},
+			"dependencies": {
+				"magic-string": {
+					"version": "0.25.1",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
+					"integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
+					"requires": {
+						"sourcemap-codec": "^1.4.1"
+					}
+				},
+				"merge-source-map": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+					"integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+					"requires": {
+						"source-map": "^0.5.6"
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
 					}
 				}
 			}
@@ -43254,6 +43686,14 @@
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
 		},
+		"svg-to-pdfkit": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/svg-to-pdfkit/-/svg-to-pdfkit-0.1.8.tgz",
+			"integrity": "sha512-QItiGZBy5TstGy+q8mjQTMGRlDDOARXLxH+sgVm1n/LYeo0zFcQlcCh8m4zi8QxctrxB9Kue/lStc/RD5iLadQ==",
+			"requires": {
+				"pdfkit": ">=0.8.1"
+			}
+		},
 		"svgo": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -43829,6 +44269,11 @@
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
 			"optional": true
 		},
+		"tiny-inflate": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+			"integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+		},
 		"tiny-warning": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -44308,10 +44753,51 @@
 			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
 			"integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
 		},
+		"unicode-properties": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.3.1.tgz",
+			"integrity": "sha512-nIV3Tf3LcUEZttY/2g4ZJtGXhWwSkuLL+rCu0DIAMbjyVPj+8j5gNVz4T/sVbnQybIsd5SFGkPKg/756OY6jlA==",
+			"requires": {
+				"base64-js": "^1.3.0",
+				"unicode-trie": "^2.0.0"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+				},
+				"unicode-trie": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+					"integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+					"requires": {
+						"pako": "^0.2.5",
+						"tiny-inflate": "^1.0.0"
+					}
+				}
+			}
+		},
 		"unicode-property-aliases-ecmascript": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
 			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+		},
+		"unicode-trie": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-1.0.0.tgz",
+			"integrity": "sha512-v5raLKsobbFbWLMoX9+bChts/VhPPj3XpkNr/HbqkirXR1DPk8eo9IYKyvk0MQZFkaoRsFj2Rmaqgi2rfAZYtA==",
+			"requires": {
+				"pako": "^0.2.5",
+				"tiny-inflate": "^1.0.0"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+				}
+			}
 		},
 		"unified": {
 			"version": "9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25077,6 +25077,18 @@
 			"requires": {
 				"is-empty": "^1.2.0",
 				"is-whitespace": "^0.3.0"
+			},
+			"dependencies": {
+				"is-empty": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
+					"integrity": "sha1-3pu1snhzigWgsJpX4ftNSjQan2s="
+				},
+				"is-whitespace": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+					"integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38="
+				}
 			}
 		},
 		"is-buffer": {
@@ -25186,11 +25198,6 @@
 				"is-object": "^1.0.1",
 				"is-window": "^1.0.2"
 			}
-		},
-		"is-empty": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
-			"integrity": "sha1-3pu1snhzigWgsJpX4ftNSjQan2s="
 		},
 		"is-expression": {
 			"version": "3.0.0",
@@ -25580,11 +25587,6 @@
 			"requires": {
 				"is-invalid-path": "^0.1.0"
 			}
-		},
-		"is-whitespace": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
-			"integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38="
 		},
 		"is-whitespace-character": {
 			"version": "1.0.4",
@@ -34179,19 +34181,23 @@
 			"dependencies": {
 				"async": {
 					"version": "3.2.0",
-					"bundled": true
+					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/async/-/async-3.2.0.tgz",
+					"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
 				},
 				"lodash": {
 					"version": "4.17.15",
-					"bundled": true
+					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 				},
 				"minimist": {
 					"version": "0.0.10",
-					"bundled": true
+					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
 				},
 				"optimist": {
 					"version": "0.6.1",
-					"bundled": true,
+					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/optimist/-/optimist-0.6.1.tgz",
+					"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 					"requires": {
 						"minimist": "~0.0.1",
 						"wordwrap": "~0.0.2"
@@ -34199,11 +34205,13 @@
 				},
 				"wordwrap": {
 					"version": "0.0.3",
-					"bundled": true
+					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/wordwrap/-/wordwrap-0.0.3.tgz",
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 				},
 				"xmldom": {
 					"version": "0.3.0",
-					"bundled": true
+					"resolved": "https://artifact.devsnc.com/content/groups/npm-all/xmldom/-/xmldom-0.3.0.tgz",
+					"integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g=="
 				}
 			}
 		},

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -3,9 +3,9 @@
   "version": "0.93.1",
   "private": true,
   "dependencies": {
-    "@accordproject/cicero-core": "^0.20.11-20200626165149",
-    "@accordproject/markdown-slate": "^0.11.4-20200626164143",
-    "@accordproject/markdown-transform": "^0.11.4-20200626164143",
+    "@accordproject/cicero-core": "^0.20.11-20200707140253",
+    "@accordproject/markdown-slate": "^0.11.4-20200707133347",
+    "@accordproject/markdown-transform": "^0.11.4-20200707133347",
     "@accordproject/ui-components": "0.93.1",
     "@accordproject/ui-concerto": "0.93.1",
     "@accordproject/ui-markdown-editor": "0.93.1",

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -32,6 +32,7 @@ const Wrapper = styled.div`
 export default { title: 'Contract Editor' };
 
 const templates = {
+  'Optional Clause': 'https://parserv2--templates-accordproject.netlify.app/archives/latedeliveryandpenalty-optional@0.1.0.cta',
   'Late Delivery And Penalty': 'https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta',
   'Fragile Goods': 'https://templates.accordproject.org/archives/fragile-goods@0.13.1.cta'
 };
@@ -40,7 +41,7 @@ export const contractEditor = () => {
   const markdownText = text( 'Markdown', `# Heading One
 This is text. This is *italic* text. This is **bold** text. This is a [link](https://clause.io). This is \`inline code\`.  
 `);
-  const templateUrl = select('Template Archive URL', templates, 'https://templates.accordproject.org/archives/latedeliveryandpenalty@0.15.0.cta');
+  const templateUrl = select('Template Archive URL', templates, 'https://parserv2--templates-accordproject.netlify.app/archives/latedeliveryandpenalty-optional@0.1.0.cta');
   const lockText = boolean('lockText', true);
   const readOnly = boolean('readOnly', false);
   const [slateValue, setSlateValue] = useState( () => {

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -24,7 +24,7 @@ const Wrapper = styled.div`
     margin: 10px auto;
     padding: 1.0em 10px 1.2em 15px;
     border-left: 3px solid #484848;
-    line-height: 1.4285em;
+    line-height: 1.5em;
     position: relative;
   }
 `;

--- a/packages/ui-contract-editor/package.json
+++ b/packages/ui-contract-editor/package.json
@@ -4,9 +4,9 @@
   "private": false,
   "dependencies": {
     "@accordproject/ui-markdown-editor": "0.93.1",
-    "@accordproject/markdown-html": "^0.11.4-20200626164143",
-    "@accordproject/markdown-slate": "^0.11.4-20200626164143",
-    "@accordproject/markdown-transform": "^0.11.4-20200626164143",
+    "@accordproject/markdown-html": "^0.11.4-20200707133347",
+    "@accordproject/markdown-slate": "^0.11.4-20200707133347",
+    "@accordproject/markdown-transform": "^0.11.4-20200707133347",
     "@babel/runtime": "^7.10.3",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",

--- a/packages/ui-contract-editor/src/lib/ContractEditor/index.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/index.js
@@ -75,6 +75,16 @@ const ContractEditor = (props) => {
     pasteToContract: props.pasteToContract
   };
 
+  const isOptionalVariable = (target, editor) => {
+    const TARGET_NODE = ReactEditor.toSlateNode(editor, target);
+    const TARGET_PATH = ReactEditor.findPath(editor, TARGET_NODE);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [currNode] of Node.ancestors(editor, TARGET_PATH, { reverse: true })) {
+      if (currNode.type === 'variable') return true;
+    }
+    return false;
+  };
+
   const customElements = (attributes, children, element, editor) => {
     const returnObject = {
       clause: () => (
@@ -96,7 +106,12 @@ const ContractEditor = (props) => {
         <Conditional readOnly={props.readOnly} attributes={attributes}>{children}</Conditional>
       ),
       optional: () => (
-        <Optional readOnly={props.readOnly} attributes={attributes}>{children}</Optional>
+        <Optional
+          readOnly={props.readOnly}
+          isOptionalVariable={isOptionalVariable}
+          attributes={attributes}>
+            {children}
+        </Optional>
       ),
       formula: () => (
         <span id={element.data.id} {...attributes} className={FORMULA}>{children}</span>

--- a/packages/ui-contract-editor/src/lib/ContractEditor/index.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/index.js
@@ -75,16 +75,6 @@ const ContractEditor = (props) => {
     pasteToContract: props.pasteToContract
   };
 
-  const isOptionalVariable = (target, editor) => {
-    const TARGET_NODE = ReactEditor.toSlateNode(editor, target);
-    const TARGET_PATH = ReactEditor.findPath(editor, TARGET_NODE);
-    // eslint-disable-next-line no-restricted-syntax
-    for (const [currNode] of Node.ancestors(editor, TARGET_PATH, { reverse: true })) {
-      if (currNode.type === 'variable') return true;
-    }
-    return false;
-  };
-
   const customElements = (attributes, children, element, editor) => {
     const returnObject = {
       clause: () => (
@@ -106,12 +96,7 @@ const ContractEditor = (props) => {
         <Conditional readOnly={props.readOnly} attributes={attributes}>{children}</Conditional>
       ),
       optional: () => (
-        <Optional
-          readOnly={props.readOnly}
-          isOptionalVariable={isOptionalVariable}
-          attributes={attributes}>
-            {children}
-        </Optional>
+        <Optional readOnly={props.readOnly} attributes={attributes}>{children}</Optional>
       ),
       formula: () => (
         <span id={element.data.id} {...attributes} className={FORMULA}>{children}</span>

--- a/packages/ui-contract-editor/src/lib/ContractEditor/index.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/index.js
@@ -24,6 +24,7 @@ import _ from 'lodash';
 import { MarkdownEditor } from '@accordproject/ui-markdown-editor';
 import ClauseComponent from '../components/Clause';
 import Conditional from '../components/Conditional';
+import Optional from '../components/Optional';
 
 /* Plugins */
 import withClauseSchema, { CLAUSE, FORMULA, VARIABLE } from './plugins/withClauseSchema';
@@ -93,6 +94,9 @@ const ContractEditor = (props) => {
       ),
       conditional: () => (
         <Conditional readOnly={props.readOnly} attributes={attributes}>{children}</Conditional>
+      ),
+      optional: () => (
+        <Optional readOnly={props.readOnly} attributes={attributes}>{children}</Optional>
       ),
       formula: () => (
         <span id={element.data.id} {...attributes} className={FORMULA}>{children}</span>

--- a/packages/ui-contract-editor/src/lib/ContractEditor/plugins/withClauseSchema.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/plugins/withClauseSchema.js
@@ -1,9 +1,10 @@
 export const CLAUSE = 'clause';
 export const VARIABLE = 'variable';
 export const CONDITIONAL = 'conditional';
+export const OPTIONAL = 'optional';
 export const FORMULA = 'formula';
 
-const INLINES = { [VARIABLE]: true, [CONDITIONAL]: true };
+const INLINES = { [VARIABLE]: true, [CONDITIONAL]: true, [OPTIONAL]: true };
 const VOIDS = {};
 
 /* eslint no-param-reassign: 0 */

--- a/packages/ui-contract-editor/src/lib/components/Optional/OptionalBoolean.js
+++ b/packages/ui-contract-editor/src/lib/components/Optional/OptionalBoolean.js
@@ -1,0 +1,69 @@
+/* React */
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+/* Styling */
+import { ClauseContext } from '../Clause';
+import { ClauseOptional, ClauseOptionalTooltip } from '../styles';
+
+import * as optionalIcon from '../../icons/conditional';
+
+/**
+ * Component to render an addition symbol for an empty optional
+ * This will have an key property of the Slate node
+ * @param {*} props
+ */
+const OptionalBoolean = (props) => {
+  const [hoveringOptional, setHoveringOptional] = useState(false);
+  const [tooltipHeight, setTooltipHeight] = useState(0);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    setTooltipHeight(ref.current ? ref.current.offsetHeight : 0);
+  }, []);
+
+  const optionalIconProps = {
+    'aria-label': optionalIcon.type,
+    viewBox: '0 0 18 18',
+    className: 'optionalIcon',
+    onMouseEnter: () => setHoveringOptional(true),
+    onMouseLeave: () => setHoveringOptional(false),
+    onClick: props.toggleOptional
+  };
+
+  const optionalTooltip = {
+    ref,
+    currentHover: hoveringOptional,
+    className: 'optionalTooltip',
+    style: { marginTop: `-${tooltipHeight + 10}px` },
+    caretTop: tooltipHeight - 2,
+    caretLeft: 2,
+  };
+
+  return (
+    <ClauseContext.Consumer>
+      { hoveringClause => (<>
+        <ClauseOptionalTooltip
+          contentEditable={false}
+          {...optionalTooltip}
+        >
+          Show text: "{props.whenSome}"
+        </ClauseOptionalTooltip>
+        <ClauseOptional
+          contentEditable={false}
+          currentHover={hoveringClause}
+          {...optionalIconProps}
+        >
+          {optionalIcon.icon(hoveringOptional)}
+        </ClauseOptional>
+      </>) }
+    </ClauseContext.Consumer>
+  );
+};
+
+OptionalBoolean.propTypes = {
+  whenSome: PropTypes.string,
+  toggleOptional: PropTypes.func,
+};
+
+export default OptionalBoolean;

--- a/packages/ui-contract-editor/src/lib/components/Optional/OptionalSwitch.js
+++ b/packages/ui-contract-editor/src/lib/components/Optional/OptionalSwitch.js
@@ -1,0 +1,46 @@
+/* React */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/* Styling */
+import { ClauseOptionalTooltip } from '../styles';
+
+/**
+ * Component to render a tooltip
+ * Displays what the optional text will be changed to
+ * @param {*} props
+ */
+const OptionalSwitch = (props) => {
+  const optionalTooltip = {
+    className: 'optionalTooltip',
+    currentHover: props.currentHover,
+    caretTop: 21,
+    caretLeft: 2,
+    tooltipHeight: 1.85,
+  };
+  const tooltipText = props.hasSome ? props.hasNone : props.hasSome;
+  const tooltipInstructions = props.isContentShowing
+    ? 'Hide text'
+    : `Change to: "${tooltipText}"`;
+
+  return (
+    <>
+      <ClauseOptionalTooltip
+        contentEditable={false}
+        {...optionalTooltip}
+      >
+        {tooltipInstructions}
+      </ClauseOptionalTooltip>
+    </>
+  );
+};
+
+OptionalSwitch.propTypes = {
+  currentHover: PropTypes.bool,
+  isContentShowing: PropTypes.bool,
+  whenTrue: PropTypes.string,
+  hasNone: PropTypes.string,
+  hasSome: PropTypes.bool,
+};
+
+export default OptionalSwitch;

--- a/packages/ui-contract-editor/src/lib/components/Optional/index.js
+++ b/packages/ui-contract-editor/src/lib/components/Optional/index.js
@@ -1,0 +1,95 @@
+/* React */
+import React, { useState } from 'react';
+import { Editor, Transforms, Node } from 'slate';
+import PropTypes from 'prop-types';
+import { ReactEditor, useEditor } from 'slate-react';
+
+/* Plugins */
+import { OPTIONAL } from '../../ContractEditor/plugins/withClauseSchema';
+
+/* Components */
+import OptionalBoolean from './OptionalBoolean';
+import OptionalSwitch from './OptionalSwitch';
+
+/**
+ * Component to render an inline optional node
+ * This will have an id property of the Slate key
+ * @param {*} props
+ */
+const Optional = React.forwardRef((props, ref) => {
+  const {
+    attributes,
+    children,
+    children: { props: { node } },
+    children: { props: { node: { data } } },
+  } = props;
+  const editor = useEditor();
+  const [hovering, setHovering] = useState(false);
+  const optionalPath = ReactEditor.findPath(editor, node);
+  const isNotReadOnly = !props.readOnly;
+  const isContentShowing = !!Node.string(node).length;
+  const optionalReverse = {
+    object: 'inline',
+    type: OPTIONAL,
+    data: {
+      name: data.name,
+      whenSome: data.whenSome,
+      whenNone: data.whenNone,
+      hasSome: !data.hasSome,
+    },
+    children: data.hasSome ? data.whenNone : data.whenSome
+  };
+
+  const toggleOptional = (path) => {
+    Editor.withoutNormalizing(editor, () => {
+      Transforms.removeNodes(editor, { at: path });
+      Transforms.insertNodes(editor, optionalReverse, { at: path });
+    });
+  };
+
+  const optionalProps = {
+    id: data.name,
+    className: isContentShowing ? OPTIONAL : '',
+    onMouseEnter: () => setHovering(true),
+    onMouseLeave: () => setHovering(false),
+    onClick: () => toggleOptional(optionalPath),
+    ...attributes,
+    ref
+  };
+
+  const optionalSwitchProps = {
+    currentHover: hovering,
+    isContentShowing,
+    ...data,
+  };
+  const optionalIconProps = {
+    currentHover: hovering,
+    whenSome: Node.string(optionalReverse),
+    toggleOptional: () => toggleOptional(optionalPath),
+  };
+
+  return (
+    <span {...attributes}>
+    { isNotReadOnly && (isContentShowing
+      ? <OptionalSwitch {...optionalSwitchProps} />
+      : <OptionalBoolean {...optionalIconProps} />) }
+        <span {...optionalProps}>{children}</span>
+    </span>
+  );
+});
+
+Optional.displayName = 'Optional';
+
+Optional.propTypes = {
+  attributes: PropTypes.PropTypes.shape({
+    'data-key': PropTypes.string,
+  }),
+  children: PropTypes.object.isRequired,
+  editor: PropTypes.any,
+  node: PropTypes.shape({
+    data: PropTypes.obj,
+  }),
+  readOnly: PropTypes.bool,
+};
+
+export default Optional;

--- a/packages/ui-contract-editor/src/lib/components/Optional/index.js
+++ b/packages/ui-contract-editor/src/lib/components/Optional/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { ReactEditor, useEditor } from 'slate-react';
 
 /* Plugins */
-import { OPTIONAL } from '../../ContractEditor/plugins/withClauseSchema';
+import { OPTIONAL, VARIABLE } from '../../ContractEditor/plugins/withClauseSchema';
 
 /* Components */
 import OptionalBoolean from './OptionalBoolean';
@@ -20,7 +20,6 @@ const Optional = React.forwardRef((props, ref) => {
   const {
     attributes,
     children,
-    isOptionalVariable,
     children: { props: { node } },
     children: { props: { node: { data } } },
   } = props;
@@ -41,6 +40,16 @@ const Optional = React.forwardRef((props, ref) => {
     children: data.hasSome ? data.whenNone : data.whenSome
   };
 
+  const isOptionalVariable = (target) => {
+    const TARGET_NODE = ReactEditor.toSlateNode(editor, target);
+    const TARGET_PATH = ReactEditor.findPath(editor, TARGET_NODE);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const [currNode] of Node.ancestors(editor, TARGET_PATH, { reverse: true })) {
+      if (currNode.type === VARIABLE) return true;
+    }
+    return false;
+  };
+
   const swapOptional = (path) => {
     Editor.withoutNormalizing(editor, () => {
       Transforms.removeNodes(editor, { at: path });
@@ -49,7 +58,7 @@ const Optional = React.forwardRef((props, ref) => {
   };
 
   const toggleOptional = (path, target) => {
-    if (!target || !isOptionalVariable(target, editor)) {
+    if (!target || !isOptionalVariable(target)) {
       swapOptional(path);
     }
   };
@@ -97,7 +106,6 @@ Optional.propTypes = {
     data: PropTypes.obj,
   }),
   readOnly: PropTypes.bool,
-  isOptionalVariable: PropTypes.func,
 };
 
 export default Optional;

--- a/packages/ui-contract-editor/src/lib/components/Optional/index.js
+++ b/packages/ui-contract-editor/src/lib/components/Optional/index.js
@@ -20,6 +20,7 @@ const Optional = React.forwardRef((props, ref) => {
   const {
     attributes,
     children,
+    isOptionalVariable,
     children: { props: { node } },
     children: { props: { node: { data } } },
   } = props;
@@ -40,11 +41,17 @@ const Optional = React.forwardRef((props, ref) => {
     children: data.hasSome ? data.whenNone : data.whenSome
   };
 
-  const toggleOptional = (path) => {
+  const swapOptional = (path) => {
     Editor.withoutNormalizing(editor, () => {
       Transforms.removeNodes(editor, { at: path });
       Transforms.insertNodes(editor, optionalReverse, { at: path });
     });
+  };
+
+  const toggleOptional = (path, target) => {
+    if (!target || !isOptionalVariable(target, editor)) {
+      swapOptional(path);
+    }
   };
 
   const optionalProps = {
@@ -52,7 +59,7 @@ const Optional = React.forwardRef((props, ref) => {
     className: isContentShowing ? OPTIONAL : '',
     onMouseEnter: () => setHovering(true),
     onMouseLeave: () => setHovering(false),
-    onClick: () => toggleOptional(optionalPath),
+    onClick: (e) => toggleOptional(optionalPath, e.target),
     ...attributes,
     ref
   };
@@ -90,6 +97,7 @@ Optional.propTypes = {
     data: PropTypes.obj,
   }),
   readOnly: PropTypes.bool,
+  isOptionalVariable: PropTypes.func,
 };
 
 export default Optional;

--- a/packages/ui-contract-editor/src/lib/components/Optional/index.js
+++ b/packages/ui-contract-editor/src/lib/components/Optional/index.js
@@ -1,5 +1,5 @@
 /* React */
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Editor, Transforms, Node } from 'slate';
 import PropTypes from 'prop-types';
 import { ReactEditor, useEditor } from 'slate-react';
@@ -63,10 +63,15 @@ const Optional = React.forwardRef((props, ref) => {
     }
   };
 
+  const handleMouseEnter = (target) => {
+    if (target.className === OPTIONAL) { setHovering(true); }
+    if (target.className === VARIABLE) { setHovering(false); }
+  };
+
   const optionalProps = {
     id: data.name,
     className: isContentShowing ? OPTIONAL : '',
-    onMouseEnter: () => setHovering(true),
+    onMouseEnter: (e) => handleMouseEnter(e.target),
     onMouseLeave: () => setHovering(false),
     onClick: (e) => toggleOptional(optionalPath, e.target),
     ...attributes,

--- a/packages/ui-contract-editor/src/lib/components/styles.js
+++ b/packages/ui-contract-editor/src/lib/components/styles.js
@@ -94,18 +94,6 @@ export const ClauseHeader = styled.div`
 `;
 
 export const ClauseBody = styled.div`
-  .variable {
-    color: #000;
-    padding: 0 3px 1px 3px;
-  }
-  .conditional {
-    color: #000;
-    padding: 0 3px 1px 3px;
-    margin-left: 2px;
-  }
-  .computed {
-    color: #f1baff;
-  }
   li {
     transition: none;
   }

--- a/packages/ui-contract-editor/src/lib/components/styles.js
+++ b/packages/ui-contract-editor/src/lib/components/styles.js
@@ -48,6 +48,35 @@ export const ClauseConditionalTooltip = styled.span`
   }
 `;
 
+export const ClauseOptional = styled.svg`
+  visibility: ${props => (props.currentHover ? 'visible' : 'hidden')};
+`;
+
+export const ClauseOptionalTooltip = styled.span`
+  visibility: ${props => (props.currentHover ? 'visible' : 'hidden')};
+  margin-top: -${props => props.tooltipHeight}em;
+
+  &:before {
+    content: '';
+    position: absolute;
+    top: ${props => props.caretTop}px;
+    left: ${props => props.caretLeft - 1}px;
+    border-top: 5px solid #141F3C;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+  }
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: ${props => props.caretTop}px;
+    left: ${props => props.caretLeft}px;
+    border-top: 4px solid #141F3C;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+  }
+`;
+
 export const ClauseHeader = styled.div`
   visibility: ${props => (props.currentHover ? 'visible' : 'hidden')};
   font-family: serif;

--- a/packages/ui-contract-editor/src/lib/styles.css
+++ b/packages/ui-contract-editor/src/lib/styles.css
@@ -31,6 +31,7 @@ a {
 
 .optional > .variable {
     padding: 0;
+    cursor: text;
 }
 
 .optional:hover,

--- a/packages/ui-contract-editor/src/lib/styles.css
+++ b/packages/ui-contract-editor/src/lib/styles.css
@@ -12,11 +12,11 @@ a {
     border-radius: 2px;
     background-color: #fff;
     color: #000;
-    padding: 1px 3px;
 }
 
 .variable {
     border: #A4BBE7 1px solid;
+    padding: 0px 3px;
 }
 
 .computed {
@@ -27,11 +27,13 @@ a {
 .optional {
     border: #FFDDA0 1px solid;
     margin-left: 2px;
+    padding: 1px 3px;
 }
 
 .optional > .variable {
-    padding: 0;
     cursor: text;
+    box-shadow: inset 0px 0px 0px 1px #A4BBE7;
+    padding: 0px 2px;
 }
 
 .optional:hover,

--- a/packages/ui-contract-editor/src/lib/styles.css
+++ b/packages/ui-contract-editor/src/lib/styles.css
@@ -6,17 +6,22 @@ a {
     background-color: #e98181;
 }
 
-.conditional {
-    cursor: pointer;
+.conditional,
+.optional {   
+    border: #FFDDA0 1px solid;
+    border-radius: 2px;
+    background-color: #fff;
 }
 
+.optional:hover,
 .conditional:hover {
     cursor: pointer;
     background-color: #d4d8e1;
     border-radius: 2px;
 }
 
-.conditionalTooltip {
+.conditionalTooltip,
+.optionalTooltip {
     opacity: 1 !important;
     border: 1px solid #141F3C;
     border-radius: 2px;
@@ -27,7 +32,8 @@ a {
     position: absolute;
 }
 
-.conditionalIcon {
+.conditionalIcon,
+.optionalIcon {
     position: absolute;
     display: inline-block;
     transition-duration: 0.2s;
@@ -38,6 +44,7 @@ a {
 }
 
 .conditionalIcon:hover,
+.optionalIcon:hover,
 .listIcon:hover {
     cursor: pointer;
 }
@@ -58,12 +65,6 @@ a {
 
 .variable {
     border: #A4BBE7 1px solid;
-    border-radius: 2px;
-    background-color: #fff;
-}
-
-.conditional {   
-    border: #FFDDA0 1px solid;
     border-radius: 2px;
     background-color: #fff;
 }

--- a/packages/ui-contract-editor/src/lib/styles.css
+++ b/packages/ui-contract-editor/src/lib/styles.css
@@ -34,6 +34,7 @@ a {
     cursor: text;
     box-shadow: inset 0px 0px 0px 1px #A4BBE7;
     padding: 0px 2px;
+    border: #A4BBE7 0px solid;
 }
 
 .optional:hover,

--- a/packages/ui-contract-editor/src/lib/styles.css
+++ b/packages/ui-contract-editor/src/lib/styles.css
@@ -6,18 +6,37 @@ a {
     background-color: #e98181;
 }
 
+.variable,
 .conditional,
-.optional {   
-    border: #FFDDA0 1px solid;
+.optional {
     border-radius: 2px;
     background-color: #fff;
+    color: #000;
+    padding: 1px 3px;
+}
+
+.variable {
+    border: #A4BBE7 1px solid;
+}
+
+.computed {
+    color: #f1baff;
+}
+
+.conditional,
+.optional {
+    border: #FFDDA0 1px solid;
+    margin-left: 2px;
+}
+
+.optional > .variable {
+    padding: 0;
 }
 
 .optional:hover,
 .conditional:hover {
     cursor: pointer;
     background-color: #d4d8e1;
-    border-radius: 2px;
 }
 
 .conditionalTooltip,
@@ -61,10 +80,4 @@ a {
 .addListIcon{
     display: block;
     margin-top: 23px;
-}
-
-.variable {
-    border: #A4BBE7 1px solid;
-    border-radius: 2px;
-    background-color: #fff;
 }

--- a/packages/ui-markdown-editor/package.json
+++ b/packages/ui-markdown-editor/package.json
@@ -3,9 +3,9 @@
   "version": "0.93.1",
   "private": false,
   "dependencies": {
-    "@accordproject/markdown-cicero": "^0.11.4-20200626164143",
-    "@accordproject/markdown-html": "^0.11.4-20200626164143",
-    "@accordproject/markdown-slate": "^0.11.4-20200626164143",
+    "@accordproject/markdown-cicero": "^0.11.4-20200707133347",
+    "@accordproject/markdown-html": "^0.11.4-20200707133347",
+    "@accordproject/markdown-slate": "^0.11.4-20200707133347",
     "@babel/runtime": "^7.10.3",
     "image-extensions": "^1.1.0",
     "is-hotkey": "^0.1.6",


### PR DESCRIPTION
# Closes #145
Support `optional` variable types - conditionals with variables in them

### Changes
- Used very similar code to `conditional` variable support

### Flags
- Did need to repeat code from `Conditional`, DRY'd it as much as I could
- `Node.string(node)` can replace [`childReducer`](https://github.com/accordproject/web-components/blob/master/packages/ui-contract-editor/src/lib/components/actions.js#L21) from https://github.com/accordproject/web-components/pull/117
- Spacing (margin/padding) for variable inside optional could use work

### Related Issues
- https://github.com/accordproject/cicero/issues/549

### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `master` from `fork:branchname`