### PR TITLE
fix(ui-markdown-editor): add 0 to element before last in anchor and focus - i134

### DIFF
--- a/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
@@ -40,11 +40,29 @@ export const toggleBlock = (editor, format) => {
 
     if (isList(format)) {
       const listItemBlock = { type: LIST_ITEM, children: [], data: { tight: true } };
-      // eslint-disable-next-line no-restricted-syntax
+      let anchor = [];
+      let focus = [];
+      editor.selection.anchor.path.map((item,index)=>{
+      if(index===editor.selection.anchor.path.length-1){
+        anchor[index]=0
+        anchor[index+1]=item
+      }else{
+        anchor[index]=item
+      }
+       });
+      editor.selection.focus.path.map((item,index)=>{
+        if(index===editor.selection.focus.path.length-1){
+          focus[index]=0
+          focus[index+1]=item
+        }else{
+          focus[index]=item
+        }
+        });
+      // eslint-disable-next-line no-restricted-syntax  
       for (const [node, path] of Node.descendants(
         editor,
-        { from: editor.selection.anchor.path, to: editor.selection.focus.path }
-      )) {
+        { from: anchor, to: focus }
+      ))  {
         if (node.type === PARAGRAPH) {
           Transforms.wrapNodes(editor, listItemBlock, { at: path });
         }

--- a/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
@@ -40,24 +40,8 @@ export const toggleBlock = (editor, format) => {
 
     if (isList(format)) {
       const listItemBlock = { type: LIST_ITEM, children: [], data: { tight: true } };
-      let anchor = [];
-      let focus = [];
-      editor.selection.anchor.path.map((item,index)=>{
-      if(index===editor.selection.anchor.path.length-1){
-        anchor[index]=0
-        anchor[index+1]=item
-      }else{
-        anchor[index]=item
-      }
-       });
-      editor.selection.focus.path.map((item,index)=>{
-        if(index===editor.selection.focus.path.length-1){
-          focus[index]=0
-          focus[index+1]=item
-        }else{
-          focus[index]=item
-        }
-        });
+      let anchor = editor.selection.anchor.path.slice(0, -1).concat(0, editor.selection.anchor.path[editor.selection.anchor.path.length - 1]);
+      let focus = editor.selection.focus.path.slice(0, -1).concat(0, editor.selection.focus.path[editor.selection.focus.path.length - 1]);
       // eslint-disable-next-line no-restricted-syntax  
       for (const [node, path] of Node.descendants(
         editor,


### PR DESCRIPTION
# Issue #134 
### Changes
- fix(toggle block of toolbar helpers getting node and path from node descendants ):add 0 to the element before last in anchor and focus-#134

### Flags


### Related Issues
- https://github.com/accordproject/web-components/issues/134