### PR TITLE
feat(ui-components): add prop to upload template in the library component

### DIFF
--- a/packages/ui-components/src/lib/Library/Buttons/index.js
+++ b/packages/ui-components/src/lib/Library/Buttons/index.js
@@ -53,7 +53,13 @@ export const UploadComponent = props => {
 
   return (
     <ActionButton
-      onClick={props.onUploadItem}
+      type='file'
+      onClick={(event) => {
+        // React doesn't automatically reset file input
+        event.persist();
+        event.target.value = null;
+      }}
+      onChange={props.onUploadItem}
       aria-label='Import Button'
       className='ui-components__library-upload-button'
     >


### PR DESCRIPTION
Signed-off-by: Aman Sharma <mannu.poski10@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
<!--- Provide an overall summary of the pull request -->

### Changes
Add a prop to provide functionality for the user to upload their own template


### Author Checklist
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions