### PR TITLE
feat(ui-contract-editor): updates to parsing and refactors code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32611,7 +32611,7 @@
 			"dependencies": {
 				"remove-accents": {
 					"version": "0.4.2",
-					"resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
 				}
 			}

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -166,7 +166,11 @@ export const contractEditor = () => {
         clause: TEMPLATE_NAME,
         parseResult,
       });
-      return Promise.resolve([true]);
+      return Promise.resolve({
+        node: null,
+        operation: null,
+        error: null,
+      });
 
       /* XXX What do we do with this? - JS
       const something = await ciceroClause.draft({format:'slate'});
@@ -194,7 +198,11 @@ export const contractEditor = () => {
         parseError: err,
         message: err.message
       });
-      return Promise.resolve([false]);
+      return Promise.resolve({
+        node: null,
+        operation: null,
+        error: err,
+      });
     }
 
   }, [editor]);

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -166,7 +166,7 @@ export const contractEditor = () => {
         clause: TEMPLATE_NAME,
         parseResult,
       });
-      return Promise.resolve(true);
+      return Promise.resolve([true]);
 
       /* XXX What do we do with this? - JS
       const something = await ciceroClause.draft({format:'slate'});
@@ -194,7 +194,7 @@ export const contractEditor = () => {
         parseError: err,
         message: err.message
       });
-      return Promise.resolve(false);
+      return Promise.resolve([false]);
     }
 
   }, [editor]);

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -80,7 +80,7 @@ export const contractEditor = () => {
   });
   const [editor, setEditor] = useState(null);
   const [templates, setTemplates] = useState([]);
-  const templateUrl = select('Insert Template', templates);  
+  const templateUrl = select('Insert Template', templates) || "https://templates.accordproject.org/archives/acceptance-of-delivery@0.14.0.cta";  
 
   useEffect( () => {
     const templateLibrary = new TemplateLibrary();
@@ -96,11 +96,10 @@ export const contractEditor = () => {
   }, []);
 
   useEffect(() => {
-    if (editor) {
+    if (editor && templateUrl) {
       Template.fromUrl(templateUrl)
         .then(async (template) => {
           const clause = new Clause(template);
-          // console.log('clause', clause);
           clause.parse(template.getMetadata().getSample());
           const slateValueNew = await clause.draft({ format: 'slate' });
           console.log('slateValueNew', slateValueNew);
@@ -142,20 +141,19 @@ export const contractEditor = () => {
     return slateEditor;
   }, []);
 
-  const parseClause = useCallback(async (val) => {
-
-    if(!val.data.src) {
+  const parseClause = useCallback(async (clauseNode) => {
+    if(!clauseNode.data.src) {
       return Promise.resolve(true);
     }
-    const SLICE_INDEX_1 = val.data.src.lastIndexOf('/') + 1;
-    const SLICE_INDEX_2 = val.data.src.indexOf('@');
-    const TEMPLATE_NAME = val.data.src.slice(SLICE_INDEX_1, SLICE_INDEX_2);
+    const SLICE_INDEX_1 = clauseNode.data.src.lastIndexOf('/') + 1;
+    const SLICE_INDEX_2 = clauseNode.data.src.indexOf('@');
+    const TEMPLATE_NAME = clauseNode.data.src.slice(SLICE_INDEX_1, SLICE_INDEX_2);
 
     try {
       const newReduxState = store.getState();
       const value = {
         document: {
-          children: val.children
+          children: clauseNode.children
         }
       };
       const text = slateTransformer.toMarkdownCicero(value);
@@ -166,6 +164,7 @@ export const contractEditor = () => {
         clause: TEMPLATE_NAME,
         parseResult,
       });
+
       return Promise.resolve({
         node: null,
         operation: null,

--- a/packages/ui-contract-editor/src/lib/ContractEditor/plugins/withClauses.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/plugins/withClauses.js
@@ -119,7 +119,9 @@ const withClauses = (editor, withClausesProps) => {
           Transforms.removeNodes(editor, { at: path });
           Transforms.insertNodes(editor, newNode, { at: path });
         } else {
-          Transforms.setNodes(editor, { error: !success }, { at: path });
+          HistoryEditor.withoutSaving(editor, () => {
+            Transforms.setNodes(editor, { error: !success }, { at: path });
+          });
         }
       });
     }

--- a/packages/ui-contract-editor/src/lib/ContractEditor/plugins/withClauses.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/plugins/withClauses.js
@@ -88,7 +88,7 @@ const withClauses = (editor, withClausesProps) => {
 
       // if we have edited a variable, then we ensure that all
       // occurences of the variable get the new value
-      if (clauseNode && variable[0].type === VARIABLE
+      if (variable && variable[0].type === VARIABLE
         && variable[0].data && variable[0].data.name) {
         const variableName = variable[0].data.name;
         const variableIterator = Editor.nodes(editor, { match: n => n.type === VARIABLE
@@ -114,13 +114,13 @@ const withClauses = (editor, withClausesProps) => {
         }
       }
 
-      onClauseUpdated(clauseNode).then(([success, newNode]) => {
-        if (newNode) {
+      onClauseUpdated(clauseNode).then(({ node, operation, error }) => {
+        if (operation === 'replace_node' && node) {
           Transforms.removeNodes(editor, { at: path });
-          Transforms.insertNodes(editor, newNode, { at: path });
+          Transforms.insertNodes(editor, node, { at: path });
         } else {
           HistoryEditor.withoutSaving(editor, () => {
-            Transforms.setNodes(editor, { error: !success }, { at: path });
+            Transforms.setNodes(editor, { error: !!error }, { at: path });
           });
         }
       });


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Allows editing of the clause text if that clause has a `parseable` property set to `false` on its data object
- Updates the `onClauseUpdated` function to replace the clause node if it receives a new clause node after parsing
- Adds new helper function `getClauseWithPath` and refactors previous code to use it where applicable

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
~~- If an `onClauseUpdated` method is passed to the ContractEditor component, the Contract Editor now expects it to return an array where the first element is whether or not the clause successfully parsed as a boolean and the second is an optional new node to replace the previous clause node.~~
- If an `onClauseUpdated` method is passed to the ContractEditor component, the Contract Editor now expects it to return an object. This object contains the optional properties `node`, `operation`, and `error`. This will also facilitate @dselman 's work on formulae.
