### PR TITLE
fix(ui-concerto): fallback to regular input field if cannot parse relationship

### DIFF
--- a/packages/ui-concerto/src/lib/components/fields.js
+++ b/packages/ui-concerto/src/lib/components/fields.js
@@ -82,7 +82,21 @@ export const ConcertoRelationship = ({
     return null;
   }
 
-  const relationship = Relationship.fromURI(field.getModelFile().getModelManager(), value);
+  let relationship;
+  try {
+    relationship = Relationship.fromURI(field.getModelFile().getModelManager(), value);
+  } catch {
+    return ConcertoInput({
+      id,
+      field,
+      readOnly,
+      required,
+      value,
+      onFieldValueChange,
+      skipLabel,
+      type,
+    });
+  }
 
   return <Form.Field required={required}>
     <ConcertoLabel skip={skipLabel} name={field.getName()} />


### PR DESCRIPTION
Signed-off-by: Diana Lease <dianarlease@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- fix(ui-concerto): fallback to regular input field if cannot parse relationship
- Parsing a relationship with `Relationship.fromURI` will fail for older templates that do not use `resource:Type#Identifier`. In this case, fall back to the regular input field.
