### PR TITLE
chore(dep) Upgrade to Cicero 0.21.5 and markdown transform 0.12.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.5.tgz",
-			"integrity": "sha512-rRNNv39UF6RwOwxkZenvQK7j3IE4LW9syTyFkIqrXBoJTi/yDqhYBQcGPFSGoz3KBAyS4PcdVRIAlLflUAWJYQ==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.6.tgz",
+			"integrity": "sha512-siTKTT3D1nzrqr5JqSaZyyJ+48gGX7dY1uxaqx+0J2/hUzmAEiBsujQRfqYYjxjoWYTM5YwOPV9UGnK+yOtnDQ==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
-				"@accordproject/ergo-compiler": "0.21.5",
-				"@accordproject/ergo-engine": "0.21.5",
-				"@accordproject/markdown-cicero": "^0.12.7",
-				"@accordproject/markdown-common": "^0.12.7",
-				"@accordproject/markdown-html": "^0.12.7",
-				"@accordproject/markdown-slate": "^0.12.7",
-				"@accordproject/markdown-template": "^0.12.7",
+				"@accordproject/ergo-compiler": "0.21.6",
+				"@accordproject/ergo-engine": "0.21.6",
+				"@accordproject/markdown-cicero": "^0.12.8",
+				"@accordproject/markdown-common": "^0.12.8",
+				"@accordproject/markdown-html": "^0.12.8",
+				"@accordproject/markdown-slate": "^0.12.8",
+				"@accordproject/markdown-template": "^0.12.8",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
@@ -71,9 +71,9 @@
 			}
 		},
 		"@accordproject/ergo-compiler": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.5.tgz",
-			"integrity": "sha512-PAmyXtN7vizyYJ56TBrAZHwb5BTvMnWY4q8K+nkckhllxqLU7S4npc/ysAbfFnbMgiDO+rWylw/AiHtnTmXSow==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.6.tgz",
+			"integrity": "sha512-JSK0V75nZ7tCMQIaaNfWCVLHGsyA20gRoR8F7xn1AY3bjizMebN5s6cYg8BY2ODM+yWvEJz/2Tvf7eYwRX1OLw==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
 				"acorn": "5.1.2",
@@ -95,31 +95,31 @@
 			}
 		},
 		"@accordproject/ergo-engine": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.5.tgz",
-			"integrity": "sha512-pZYoTgEuoxuQr3d5K+fXS8UxrtL+IstgaMS74DNS2WLL1J5WBJFEksn3yA9IBYDwk1ADbqZfa6PaotLi18S15g==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.6.tgz",
+			"integrity": "sha512-1uc9nhuUyV11I89rKFsY29+q+qUmPG6Haqw4bYV8gM+mTRmamvu0zYQsjhyAchVONyXtxHbn8GOkel++Z35ZyA==",
 			"requires": {
-				"@accordproject/ergo-compiler": "0.21.5",
+				"@accordproject/ergo-compiler": "0.21.6",
 				"moment-mini": "2.22.1",
 				"vm2": "3.5.0"
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.7.tgz",
-			"integrity": "sha512-ddDkYdPZLGo3FmfArfriCpIAaV/nehHj8zifm4l1u4jdFzzZ3m4yUPZ4LFxWYvqVRklbNJhV8ZpOEd5riXYoWQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.8.tgz",
+			"integrity": "sha512-YPblroHXepJons2U98cIeFu3+Oi/kJOwQSQNLlU6pW1PxUXh8+S0v7+mPoxywT5X5bA1ktYU/ZipW1Z7D0pppA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-common": "0.12.7",
-				"@accordproject/markdown-it-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.8",
+				"@accordproject/markdown-it-cicero": "0.12.8",
 				"markdown-it": "^11.0.0",
 				"winston": "3.2.1"
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.7.tgz",
-			"integrity": "sha512-r+KKRL2u+3YHBaeMaDbWTXYnna0ylYHDO0zxEAWXyK2gbQkl6PalW+1GTZSdGx6j2sDwtTIKQCLfQnZiyMBs9w==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.8.tgz",
+			"integrity": "sha512-fetAC2LEE6Vx/TQH8EDftEzdtawts4SpTPPcEsr+vy8/4wziNBBNNsL4vexf/EOl7NQyQ+mzu04lKLt9tMIiPA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
 				"markdown-it": "^11.0.0",
@@ -128,71 +128,71 @@
 			}
 		},
 		"@accordproject/markdown-docx": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.12.7.tgz",
-			"integrity": "sha512-gaR0X86xhJemOa/wuGXTcSxT2x6Ea0bcR6cRXGMYeWlvMo2o+dYN2/Y+Dc/QsGA2dKXy8thCYjDUbZ2DBmhURg==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.12.8.tgz",
+			"integrity": "sha512-5uXWBZzq0KGv31eRN+e5qs96uZmcOHmkLwi+NIGl0Ypxql8np6bFRHX8JnznVHPa0UtSV+CQUNX6r+BSPswRKA==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
 				"mammoth": "^1.4.9"
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.7.tgz",
-			"integrity": "sha512-z1alqV238Ok9JNR2p/IEs1et4LMcPtOIZ0QuPpAm9x6y8n2ScK98zTD7ko94J5/YnZ2m4g80HHY8UySMHXeA+g==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.8.tgz",
+			"integrity": "sha512-YiZLJfUGUT4obT2hja4Q+I/kRMti+Ip5GFR4ZBli701ZY9b4I/hvf9cayG9qKyJSnODwHBuNh/RDeWEH0Ji8lw==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-it-cicero": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.7.tgz",
-			"integrity": "sha512-jGUQ8lfBGZuh68MDweag1y1fwo1kQF/8nBPvuW2MHJpKOg1E+n38P3EuxXOumh0iglbtD8pBGC4qm0OMvVP+rQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.8.tgz",
+			"integrity": "sha512-fEtHqV0vOhOHICDh9tYukDNVdclvLcCVc5l6fFf7MXwyJi5xOEbao+ckTPotjH3oxGc3PXWcnaQzjGfIXxp+Fg==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.7.tgz",
-			"integrity": "sha512-JqqHv/ls9wr6Xrj0VAjzjUQdbVuPb7Dxmif1EIyHrvnAAXIWVleqMYLeVgXD9QZf67Whv5vkK0vf+9OmtbomXA==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.8.tgz",
+			"integrity": "sha512-wINlXtKTsHWjybDa3vkL40mF7HFLGAHJV64tJ/d0Csp/enE7KwzRu2Xtq53CJKd6rfi2CcjSga1Jx9rG2zimcA==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-pdf": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.12.7.tgz",
-			"integrity": "sha512-mwgECdwYlmeXUW0JZIq/eIDyDwOTfDqjOAu1kW9RDJebHONpSyw85uhwy4pSD66h2ZGdHtl626jo0LjoW7hdUA==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.12.8.tgz",
+			"integrity": "sha512-4PwlOo+UGOJjrTsq4K2u7scY9EjQxKxTt3yIKDv1hlPK0PIP51CjsI+8ktzMhdyesywNcIg7ewiGRVGa5Lxb9A==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
-				"pdf2json": "1.2.0",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
+				"pdfjs-dist": "^2.4.456",
 				"pdfmake": "0.1.66",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.7.tgz",
-			"integrity": "sha512-Rl2gVoyrOM/n7+nwRlmYBXpw4HEw3/DPU2/YGzCPPX/vFD8IB0982KNB1fBgXsNHZEOoUOaD1G8ruRRWE+Q5nQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.8.tgz",
+			"integrity": "sha512-yl6cune3+FfuQdsOgeolC4rpL6JdVDs3soGK0paRjZtbqb/efu7+JhGdl/px+nh/idCbhKH3MoACbkpReNmAvg==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.7"
+				"@accordproject/markdown-cicero": "0.12.8"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.7.tgz",
-			"integrity": "sha512-K8q0lAoDmdou8NHYWt7ASPfdn8XU/s5obrFm3rrKJveolQIUVxCNrZzv+qSwNm72JdOX/sNDQ67tNuqaDbFQSg==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.8.tgz",
+			"integrity": "sha512-xJW4QvrdAWz3Rvp5YtkrPVfZ8CFs2oluJ6F+bTZPWiDaleNvrjwAlpGbv1avWaY2beqsQ6vjTmilX4RvtA0G0w==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
-				"@accordproject/markdown-it-template": "0.12.7",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
+				"@accordproject/markdown-it-template": "0.12.8",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",
@@ -200,18 +200,18 @@
 			}
 		},
 		"@accordproject/markdown-transform": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.12.7.tgz",
-			"integrity": "sha512-oG1sicGDFGy5w2iO4XRoCpadQXCMTCTeYj1CSAAy4I/b7+5ErgJhjs8/xzQXgcB1Bu/rKDsjH0CYl6Osv7jSHg==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.12.8.tgz",
+			"integrity": "sha512-KZHvf14ploRKruxIAs70At5gFztWFRCctqn05PFveVzwFbOSiWOjNubK1f/0AjFSDRnPZgA+Oe3kZDhTBoFXwA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
-				"@accordproject/markdown-docx": "0.12.7",
-				"@accordproject/markdown-html": "0.12.7",
-				"@accordproject/markdown-pdf": "0.12.7",
-				"@accordproject/markdown-slate": "0.12.7",
-				"@accordproject/markdown-template": "0.12.7",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
+				"@accordproject/markdown-docx": "0.12.8",
+				"@accordproject/markdown-html": "0.12.8",
+				"@accordproject/markdown-pdf": "0.12.8",
+				"@accordproject/markdown-slate": "0.12.8",
+				"@accordproject/markdown-template": "0.12.8",
 				"dijkstrajs": "^1.0.1",
 				"moment-mini": "2.22.1"
 			}
@@ -36884,46 +36884,10 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"pdf2json": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-1.2.0.tgz",
-			"integrity": "sha512-Z/m+OFOe13Nn2SHQNSINZ6Mh2b8t2bK3whL3L6b5Av1wqDvotYvpMg1Zi8aEPV37jF0jG0yQ83c8XuuNbIsn6Q==",
-			"requires": {
-				"async": "^3.2.0",
-				"lodash": "^4.17.13",
-				"optimist": "^0.6.1",
-				"xmldom": "^0.3.0"
-			},
-			"dependencies": {
-				"async": {
-					"version": "3.2.0",
-					"bundled": true
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"bundled": true
-				},
-				"minimist": {
-					"version": "0.0.10",
-					"bundled": true
-				},
-				"optimist": {
-					"version": "0.6.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "~0.0.1",
-						"wordwrap": "~0.0.2"
-					}
-				},
-				"wordwrap": {
-					"version": "0.0.3",
-					"bundled": true
-				},
-				"xmldom": {
-					"version": "0.3.0",
-					"bundled": true
-				}
-			}
+		"pdfjs-dist": {
+			"version": "2.4.456",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.4.456.tgz",
+			"integrity": "sha512-yckJEHq3F48hcp6wStEpbN9McOj328Ib09UrBlGAKxvN2k+qYPN5iq6TH6jD1C0pso7zTep+g/CKsYgdrQd5QA=="
 		},
 		"pdfkit": {
 			"version": "0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
 	"name": "@accordproject/web-components",
-	"version": "0.95.0",
+	"version": "0.95.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.4.tgz",
-			"integrity": "sha512-xM5v1vahLORMC5H3RbzpCtOoCtoOhs8wO3X8ZPff0QI+pXMCkx9/XZPa9aNEJKVb0hwBr2PKzRwdylrdYExYdQ==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.5.tgz",
+			"integrity": "sha512-rRNNv39UF6RwOwxkZenvQK7j3IE4LW9syTyFkIqrXBoJTi/yDqhYBQcGPFSGoz3KBAyS4PcdVRIAlLflUAWJYQ==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
-				"@accordproject/ergo-compiler": "0.21.4",
-				"@accordproject/ergo-engine": "0.21.4",
-				"@accordproject/markdown-cicero": "^0.12.6",
-				"@accordproject/markdown-common": "^0.12.6",
-				"@accordproject/markdown-html": "^0.12.6",
-				"@accordproject/markdown-slate": "^0.12.6",
-				"@accordproject/markdown-template": "^0.12.6",
+				"@accordproject/ergo-compiler": "0.21.5",
+				"@accordproject/ergo-engine": "0.21.5",
+				"@accordproject/markdown-cicero": "^0.12.7",
+				"@accordproject/markdown-common": "^0.12.7",
+				"@accordproject/markdown-html": "^0.12.7",
+				"@accordproject/markdown-slate": "^0.12.7",
+				"@accordproject/markdown-template": "^0.12.7",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
@@ -71,9 +71,9 @@
 			}
 		},
 		"@accordproject/ergo-compiler": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.4.tgz",
-			"integrity": "sha512-xptuc0+S9WpEKhX1XHksc6GpDD1JPYjRy9W3VkQkOAYfV5ISe1pCN9xxeLKToQlTtCNsrjUyVo5+N+U/8JHqTA==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.5.tgz",
+			"integrity": "sha512-PAmyXtN7vizyYJ56TBrAZHwb5BTvMnWY4q8K+nkckhllxqLU7S4npc/ysAbfFnbMgiDO+rWylw/AiHtnTmXSow==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
 				"acorn": "5.1.2",
@@ -95,31 +95,31 @@
 			}
 		},
 		"@accordproject/ergo-engine": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.4.tgz",
-			"integrity": "sha512-LLqSb2hVkdQDe9HX+mar7yn0ZfHQToh+yOqTMVNyT0ft9mDZKPnp9GUlRD9/eSGSh6sZIOOI//HBZaH6IqVpbQ==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.5.tgz",
+			"integrity": "sha512-pZYoTgEuoxuQr3d5K+fXS8UxrtL+IstgaMS74DNS2WLL1J5WBJFEksn3yA9IBYDwk1ADbqZfa6PaotLi18S15g==",
 			"requires": {
-				"@accordproject/ergo-compiler": "0.21.4",
+				"@accordproject/ergo-compiler": "0.21.5",
 				"moment-mini": "2.22.1",
 				"vm2": "3.5.0"
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.6.tgz",
-			"integrity": "sha512-8qs7BpIP4VN4Ljc71MXryeGv4UacvhpqF0tKlF8oCFtPFw51NDidoB5VNnftFKVoxwXVpgS+QC73rSdxkUQ/gA==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.7.tgz",
+			"integrity": "sha512-ddDkYdPZLGo3FmfArfriCpIAaV/nehHj8zifm4l1u4jdFzzZ3m4yUPZ4LFxWYvqVRklbNJhV8ZpOEd5riXYoWQ==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-common": "0.12.6",
-				"@accordproject/markdown-it-cicero": "0.12.6",
+				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-it-cicero": "0.12.7",
 				"markdown-it": "^11.0.0",
 				"winston": "3.2.1"
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.6.tgz",
-			"integrity": "sha512-nXi/BfnF66Pzvn6lxBCtuB6CLL2v6xPfmNvb+psv4fnFvl/sKYzbBHPt1VOMUZIIOdTsmHNG/ac4qc96S4jQ1Q==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.7.tgz",
+			"integrity": "sha512-r+KKRL2u+3YHBaeMaDbWTXYnna0ylYHDO0zxEAWXyK2gbQkl6PalW+1GTZSdGx6j2sDwtTIKQCLfQnZiyMBs9w==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
 				"markdown-it": "^11.0.0",
@@ -128,72 +128,71 @@
 			}
 		},
 		"@accordproject/markdown-docx": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.12.6.tgz",
-			"integrity": "sha512-zZGPArxfQXqVc3v+rK21UG/g28CzUTP4jm+Sk2N3vTif7VUevH7nmYD2UWtSrk9Z3y8ums+08GCuKqOLJ6IbuQ==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-docx/-/markdown-docx-0.12.7.tgz",
+			"integrity": "sha512-gaR0X86xhJemOa/wuGXTcSxT2x6Ea0bcR6cRXGMYeWlvMo2o+dYN2/Y+Dc/QsGA2dKXy8thCYjDUbZ2DBmhURg==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
 				"mammoth": "^1.4.9"
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.6.tgz",
-			"integrity": "sha512-E1l/Fqa23nzc3sa/Ry2RDYR160WlcUuNYy6aEFzbJXmfeCyv0YpYXVgu6DD2dg8tnFChTZTErn61TnKRlronEA==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.7.tgz",
+			"integrity": "sha512-z1alqV238Ok9JNR2p/IEs1et4LMcPtOIZ0QuPpAm9x6y8n2ScK98zTD7ko94J5/YnZ2m4g80HHY8UySMHXeA+g==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-it-cicero": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.6.tgz",
-			"integrity": "sha512-Ey50zTBDjzwtPcfn/ckhTz9fPRq5T0rBH2zFpZ1baz79TTCqczo7QyHpvDiKNz+zKazqRwq9Ss5WVRxqYlp7RQ==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.7.tgz",
+			"integrity": "sha512-jGUQ8lfBGZuh68MDweag1y1fwo1kQF/8nBPvuW2MHJpKOg1E+n38P3EuxXOumh0iglbtD8pBGC4qm0OMvVP+rQ==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.6.tgz",
-			"integrity": "sha512-500aC0BiU5dNLaT201upbLAOWkxyVPeWu8HAfpQBE1SFBx75DehUCZd2nUOyEVthoTl9lychMO0xg1XuHmy4uw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.7.tgz",
+			"integrity": "sha512-JqqHv/ls9wr6Xrj0VAjzjUQdbVuPb7Dxmif1EIyHrvnAAXIWVleqMYLeVgXD9QZf67Whv5vkK0vf+9OmtbomXA==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-pdf": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.12.6.tgz",
-			"integrity": "sha512-dSYfTvznnOxb1HNdYGSENn8JBK1M34x5MOhVUUgfq41ygNZV0kWDQxFl7RgGub6R+MmrLJeZIum3eEOV8ePalQ==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-pdf/-/markdown-pdf-0.12.7.tgz",
+			"integrity": "sha512-mwgECdwYlmeXUW0JZIq/eIDyDwOTfDqjOAu1kW9RDJebHONpSyw85uhwy4pSD66h2ZGdHtl626jo0LjoW7hdUA==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
-				"easy-pdf-parser": "0.0.4",
-				"jsdom": "^15.2.1",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
+				"pdf2json": "1.2.0",
 				"pdfmake": "0.1.66",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.6.tgz",
-			"integrity": "sha512-mExTe4757syubAVFtDqixuKS8CUfFT1w2xInp49eve75BwCCXHb5lBVd4BqZ7363Skju8ORnePkL6NkvDtKivw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.7.tgz",
+			"integrity": "sha512-Rl2gVoyrOM/n7+nwRlmYBXpw4HEw3/DPU2/YGzCPPX/vFD8IB0982KNB1fBgXsNHZEOoUOaD1G8ruRRWE+Q5nQ==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.6"
+				"@accordproject/markdown-cicero": "0.12.7"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.6.tgz",
-			"integrity": "sha512-QpBDObzYkYvpTQaFzsL9I0+Z8YsyYZqIL7f7OzDegd64G+h+ELCgVaLo/9fuRsY8rDVjAh/ui2WHosMLkab1vw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.7.tgz",
+			"integrity": "sha512-K8q0lAoDmdou8NHYWt7ASPfdn8XU/s5obrFm3rrKJveolQIUVxCNrZzv+qSwNm72JdOX/sNDQ67tNuqaDbFQSg==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
-				"@accordproject/markdown-it-template": "0.12.6",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-it-template": "0.12.7",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",
@@ -201,18 +200,18 @@
 			}
 		},
 		"@accordproject/markdown-transform": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.12.6.tgz",
-			"integrity": "sha512-/P7Zpj+Ka0Iyf/jBc4s28cEncQMTBvmjcXDo+V9xf+sMvQGI/qRe+UYjr5Eu1LLDT5QXO9ueM8qf8S/HkK5yXg==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-transform/-/markdown-transform-0.12.7.tgz",
+			"integrity": "sha512-oG1sicGDFGy5w2iO4XRoCpadQXCMTCTeYj1CSAAy4I/b7+5ErgJhjs8/xzQXgcB1Bu/rKDsjH0CYl6Osv7jSHg==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
-				"@accordproject/markdown-docx": "0.12.6",
-				"@accordproject/markdown-html": "0.12.6",
-				"@accordproject/markdown-pdf": "0.12.6",
-				"@accordproject/markdown-slate": "0.12.6",
-				"@accordproject/markdown-template": "0.12.6",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-docx": "0.12.7",
+				"@accordproject/markdown-html": "0.12.7",
+				"@accordproject/markdown-pdf": "0.12.7",
+				"@accordproject/markdown-slate": "0.12.7",
+				"@accordproject/markdown-template": "0.12.7",
 				"dijkstrajs": "^1.0.1",
 				"moment-mini": "2.22.1"
 			}
@@ -17807,14 +17806,6 @@
 						"safe-buffer": "~5.1.0"
 					}
 				}
-			}
-		},
-		"easy-pdf-parser": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/easy-pdf-parser/-/easy-pdf-parser-0.0.4.tgz",
-			"integrity": "sha512-2uTBDrESwtnEqmtNeS3cR05+a77DSgjP/xHZeV9AWf67LX7ZnZeUOLiaunzG08/Oz4oI4KCSUSm1EaNXHoZ8Sg==",
-			"requires": {
-				"pdf2json": "^1.1.7"
 			}
 		},
 		"ecc-jsbn": {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -3,9 +3,9 @@
   "version": "0.95.2",
   "private": true,
   "dependencies": {
-    "@accordproject/cicero-core": "^0.21.5",
-    "@accordproject/markdown-slate": "^0.12.7",
-    "@accordproject/markdown-transform": "^0.12.7",
+    "@accordproject/cicero-core": "^0.21.6",
+    "@accordproject/markdown-slate": "^0.12.8",
+    "@accordproject/markdown-transform": "^0.12.8",
     "@accordproject/ui-components": "0.95.2",
     "@accordproject/ui-concerto": "0.95.2",
     "@accordproject/ui-markdown-editor": "0.95.2",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -3,9 +3,9 @@
   "version": "0.95.2",
   "private": true,
   "dependencies": {
-    "@accordproject/cicero-core": "^0.21.4",
-    "@accordproject/markdown-slate": "^0.12.6",
-    "@accordproject/markdown-transform": "^0.12.6",
+    "@accordproject/cicero-core": "^0.21.5",
+    "@accordproject/markdown-slate": "^0.12.7",
+    "@accordproject/markdown-transform": "^0.12.7",
     "@accordproject/ui-components": "0.95.2",
     "@accordproject/ui-concerto": "0.95.2",
     "@accordproject/ui-markdown-editor": "0.95.2",

--- a/packages/ui-contract-editor/package.json
+++ b/packages/ui-contract-editor/package.json
@@ -3,9 +3,9 @@
   "version": "0.95.2",
   "private": false,
   "dependencies": {
-    "@accordproject/markdown-html": "^0.12.7",
-    "@accordproject/markdown-slate": "^0.12.7",
-    "@accordproject/markdown-transform": "^0.12.7",
+    "@accordproject/markdown-html": "^0.12.8",
+    "@accordproject/markdown-slate": "^0.12.8",
+    "@accordproject/markdown-transform": "^0.12.8",
     "@accordproject/ui-markdown-editor": "0.95.2",
     "@babel/runtime": "^7.10.3",
     "lodash": "^4.17.15",

--- a/packages/ui-contract-editor/package.json
+++ b/packages/ui-contract-editor/package.json
@@ -3,9 +3,9 @@
   "version": "0.95.2",
   "private": false,
   "dependencies": {
-    "@accordproject/markdown-html": "^0.12.6",
-    "@accordproject/markdown-slate": "^0.12.6",
-    "@accordproject/markdown-transform": "^0.12.6",
+    "@accordproject/markdown-html": "^0.12.7",
+    "@accordproject/markdown-slate": "^0.12.7",
+    "@accordproject/markdown-transform": "^0.12.7",
     "@accordproject/ui-markdown-editor": "0.95.2",
     "@babel/runtime": "^7.10.3",
     "lodash": "^4.17.15",

--- a/packages/ui-markdown-editor/package.json
+++ b/packages/ui-markdown-editor/package.json
@@ -3,9 +3,9 @@
   "version": "0.95.2",
   "private": false,
   "dependencies": {
-    "@accordproject/markdown-cicero": "^0.12.6",
-    "@accordproject/markdown-html": "^0.12.6",
-    "@accordproject/markdown-slate": "^0.12.6",
+    "@accordproject/markdown-cicero": "^0.12.7",
+    "@accordproject/markdown-html": "^0.12.7",
+    "@accordproject/markdown-slate": "^0.12.7",
     "@babel/runtime": "^7.10.3",
     "image-extensions": "^1.1.0",
     "is-hotkey": "^0.1.6",

--- a/packages/ui-markdown-editor/package.json
+++ b/packages/ui-markdown-editor/package.json
@@ -3,9 +3,9 @@
   "version": "0.95.2",
   "private": false,
   "dependencies": {
-    "@accordproject/markdown-cicero": "^0.12.7",
-    "@accordproject/markdown-html": "^0.12.7",
-    "@accordproject/markdown-slate": "^0.12.7",
+    "@accordproject/markdown-cicero": "^0.12.8",
+    "@accordproject/markdown-html": "^0.12.8",
+    "@accordproject/markdown-slate": "^0.12.8",
     "@babel/runtime": "^7.10.3",
     "image-extensions": "^1.1.0",
     "is-hotkey": "^0.1.6",


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Upgrades to cicero `0.21.5` and markdown transform `0.12.7`, fixing issues with nested blocks
