### PR TITLE
feat(markdown-editor) : SHIFT+ENTER inserts a linebreak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@accordproject/web-components",
-	"version": "0.95.2",
+	"version": "0.95.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/storybook/src/stories/1-MarkdownEditor.stories.js
+++ b/packages/storybook/src/stories/1-MarkdownEditor.stories.js
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 
 import { SlateTransformer } from '@accordproject/markdown-slate';
 import { boolean } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { MarkdownEditor } from '@accordproject/ui-markdown-editor';
 
 const slateTransformer = new SlateTransformer();
@@ -84,7 +85,6 @@ export const Demo = () => {
    */
   const [slateValue, setSlateValue] = useState(() => {
     const slate = slateTransformer.fromMarkdown(defaultMarkdown);
-    console.log(slate);
     return slate.document.children;
   });
   const [markdown, setMarkdown] = useState(defaultMarkdown);
@@ -100,6 +100,7 @@ export const Demo = () => {
    * Called when the Slate Value changes
    */
   const onSlateValueChange = useCallback((slateChildren) => {
+    action('onSlateValueChange')(slateChildren);
     localStorage.setItem('slate-editor-value', JSON.stringify(slateChildren));
     const slateValue = {
       document: {
@@ -108,6 +109,7 @@ export const Demo = () => {
     };
     const markdown = slateTransformer.toMarkdown(slateValue);
     setSlateValue(slateValue.document.children);
+    action('markdown')(markdown);
     setMarkdown(markdown);
   }, []);
 

--- a/packages/ui-contract-editor/src/lib/ContractEditor/index.js
+++ b/packages/ui-contract-editor/src/lib/ContractEditor/index.js
@@ -109,8 +109,8 @@ const ContractEditor = (props) => {
 
   const customElements = (attributes, children, element, editor) => {
     const CLAUSE_PROPS = {
-      templateUri: element.data.src ? element.data.src : 'http://embedded@0.0.0#abcde',
-      name: element.data.name,
+      templateUri: (element.data && element.data.src) ? element.data.src : '',
+      name: (element.data && element.data.name) ? element.data.name : '',
       error: element.error,
       clauseProps: props.clauseProps,
       readOnly: props.readOnly,
@@ -129,7 +129,7 @@ const ContractEditor = (props) => {
       attributes
     };
     const FORMULA_PROPS = {
-      name: element.data.name,
+      name: (element.data && element.data.name) ? element.data.name : '',
       className: FORMULA,
       setHoveringFormulaContract,
       setFormulaNode,

--- a/packages/ui-markdown-editor/src/lib/components/index.js
+++ b/packages/ui-markdown-editor/src/lib/components/index.js
@@ -34,7 +34,12 @@ const Element = (props) => {
     [H5]: () => (<Heading id={headingId} as="h5" style={DROPDOWN_STYLE_H5} {...attributes}>{children}</Heading>),
     [H6]: () => (<Heading id={headingId} as="h6" style={DROPDOWN_STYLE_H6} {...attributes}>{children}</Heading>),
     [SOFTBREAK]: () => (<span className={SOFTBREAK} {...attributes}> {children}</span>),
-    [LINEBREAK]: () => (<br className={LINEBREAK} {...attributes} />),
+    [LINEBREAK]: () => (<span {...attributes}>
+      <span contentEditable={false} style={{ userSelect: 'none' }}>
+        <br />
+      </span>
+      {children}
+    </span>),
     [LINK]: () => (<a {...attributes} href={data.href}>{children}</a>),
     [HTML_BLOCK]: () => (<pre className={HTML_BLOCK} {...attributes}>{children}</pre>),
     [CODE_BLOCK]: () => (<pre {...attributes}>{children}</pre>),

--- a/packages/ui-markdown-editor/src/lib/index.js
+++ b/packages/ui-markdown-editor/src/lib/index.js
@@ -14,7 +14,7 @@ import { BUTTON_ACTIVE } from './utilities/constants';
 import withSchema from './utilities/schema';
 import Element from './components';
 import Leaf from './components/Leaf';
-import { toggleMark, toggleBlock, insertThematicBreak } from './utilities/toolbarHelpers';
+import { toggleMark, toggleBlock, insertThematicBreak, insertLinebreak } from './utilities/toolbarHelpers';
 import { withImages, insertImage } from './plugins/withImages';
 import { withLinks, isSelectionLinkBody } from './plugins/withLinks';
 import { withHtml } from './plugins/withHtml';
@@ -72,6 +72,7 @@ export const MarkdownEditor = (props) => {
       setShowLinkModal(true);
     },
     horizontal_rule: (code) => insertThematicBreak(editor, code),
+    linebreak: (code) => insertLinebreak(editor, code)
   };
 
   const onKeyDown = useCallback((event) => {
@@ -79,6 +80,7 @@ export const MarkdownEditor = (props) => {
       event.preventDefault();
       return;
     }
+
     const isFormatEvent = () => formattingHotKeys.some(hotkey => isHotkey(hotkey, event));
     if (!canBeFormatted(editor) && isFormatEvent()) {
       event.preventDefault();

--- a/packages/ui-markdown-editor/src/lib/plugins/withLists.js
+++ b/packages/ui-markdown-editor/src/lib/plugins/withLists.js
@@ -8,7 +8,7 @@ export const withLists = (editor) => {
 
   editor.insertBreak = () => {
     const currNode = Node.get(editor, editor.selection.focus.path);
-    if (currNode.object === 'text' && currNode.text === '') {
+    if (currNode.text === '') {
       // eslint-disable-next-line no-restricted-syntax
       for (const [n] of Node.ancestors(editor, editor.selection.focus.path, { reverse: true })) {
         if (ENTER_BLOCK[n.type]) {

--- a/packages/ui-markdown-editor/src/lib/utilities/hotkeys.js
+++ b/packages/ui-markdown-editor/src/lib/utilities/hotkeys.js
@@ -1,6 +1,6 @@
 import {
   LINK, IMAGE, BLOCK_QUOTE, UL_LIST, OL_LIST,
-  MARK_BOLD, MARK_ITALIC, MARK_CODE, HR
+  MARK_BOLD, MARK_ITALIC, MARK_CODE, HR, LINEBREAK
 } from './schema';
 
 const HOTKEYS = {
@@ -47,6 +47,10 @@ const HOTKEYS = {
   'mod+enter': {
     type: 'horizontal_rule',
     code: HR,
+  },
+  'shift+enter': {
+    type: 'linebreak',
+    code: LINEBREAK,
   }
 };
 
@@ -60,7 +64,7 @@ export const ENTER_BLOCK = {
   ...ENTER_LIST
 };
 
-export const formattingHotKeys = ['mod+b', 'mod+i', 'mod+shift+7', 'mod+shift+8', 'mod+shift+9', 'mod+shift+.', 'mod+shift+g', 'mod+k', 'mod+enter'];
+export const formattingHotKeys = ['mod+b', 'mod+i', 'mod+shift+7', 'mod+shift+8', 'mod+shift+9', 'mod+shift+.', 'mod+shift+g', 'mod+k', 'mod+enter', 'shift+enter'];
 
 export const ENTER = 'enter';
 export const ENTER_SHIFT = 'shift+enter';

--- a/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
@@ -93,7 +93,7 @@ export const insertThematicBreak = (editor, type) => {
 
 export const insertLinebreak = (editor, type) => {
   const text = { object: 'text', text: '' };
-  const br = { type, children: [text] };
+  const br = { type, children: [text], data: {} };
   Transforms.insertNodes(editor, br);
   Transforms.move(editor, { distance: 1, unit: 'character' });
 };

--- a/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
@@ -1,6 +1,6 @@
 import { Node, Editor, Transforms } from 'slate';
 import {
-  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH
+  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH, LINEBREAK
 } from './schema';
 
 export const isBlockActive = (editor, format) => {
@@ -40,13 +40,13 @@ export const toggleBlock = (editor, format) => {
 
     if (isList(format)) {
       const listItemBlock = { type: LIST_ITEM, children: [], data: { tight: true } };
-      let anchor = editor.selection.anchor.path.slice(0, -1).concat(0, editor.selection.anchor.path[editor.selection.anchor.path.length - 1]);
-      let focus = editor.selection.focus.path.slice(0, -1).concat(0, editor.selection.focus.path[editor.selection.focus.path.length - 1]);
-      // eslint-disable-next-line no-restricted-syntax  
+      const anchor = editor.selection.anchor.path.slice(0, -1).concat(0, editor.selection.anchor.path[editor.selection.anchor.path.length - 1]);
+      const focus = editor.selection.focus.path.slice(0, -1).concat(0, editor.selection.focus.path[editor.selection.focus.path.length - 1]);
+      // eslint-disable-next-line no-restricted-syntax
       for (const [node, path] of Node.descendants(
         editor,
         { from: anchor, to: focus }
-      ))  {
+      )) {
         if (node.type === PARAGRAPH) {
           Transforms.wrapNodes(editor, listItemBlock, { at: path });
         }
@@ -89,4 +89,11 @@ export const insertThematicBreak = (editor, type) => {
     },
   ];
   Transforms.insertNodes(editor, tBreakNode);
+};
+
+export const insertLinebreak = (editor, type) => {
+  const text = { text: '' };
+  const br = { type, children: [text] };
+  Transforms.insertNodes(editor, br);
+  Transforms.move(editor, { distance: 1, unit: 'character' });
 };

--- a/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/lib/utilities/toolbarHelpers.js
@@ -1,6 +1,6 @@
 import { Node, Editor, Transforms } from 'slate';
 import {
-  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH, LINEBREAK
+  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH
 } from './schema';
 
 export const isBlockActive = (editor, format) => {
@@ -72,7 +72,7 @@ export const toggleHistory = (editor, format) => {
 };
 
 export const insertThematicBreak = (editor, type) => {
-  const text = { text: '' };
+  const text = { object: 'text', text: '' };
   const tBreakNode = [
     {
       object: 'block',
@@ -92,7 +92,7 @@ export const insertThematicBreak = (editor, type) => {
 };
 
 export const insertLinebreak = (editor, type) => {
-  const text = { text: '' };
+  const text = { object: 'text', text: '' };
   const br = { type, children: [text] };
   Transforms.insertNodes(editor, br);
   Transforms.move(editor, { distance: 1, unit: 'character' });


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

# Closes #153 

Also: https://github.com/accordproject/web-components/issues/182
Also: https://github.com/accordproject/web-components/issues/49
Also: https://github.com/accordproject/web-components/issues/41

### Changes
- Adds a keyboard handler for SHIFT+ENTER which inserts a LINEBREAK into the Slate DOM

### Flags
- HTML copy/paste requires a fix in markdown-html

### Screenshots or Video
https://www.loom.com/share/a1458a6fece0468088e2fef776e99d8f
