### PR TITLE
The z-index of optionaltooltip was set to 1000 Clause template buttons overlap tooltips #185 solved

### DIFF
--- a/packages/ui-contract-editor/src/lib/components/Optional/OptionalBoolean.js
+++ b/packages/ui-contract-editor/src/lib/components/Optional/OptionalBoolean.js
@@ -35,7 +35,7 @@ const OptionalBoolean = (props) => {
     ref,
     currentHover: hoveringOptional,
     className: 'optionalTooltip',
-    style: { marginTop: `-${tooltipHeight + 10}px` },
+    style: { marginTop: `-${tooltipHeight + 10}px`,zIndex:10000 },
     caretTop: tooltipHeight - 2,
     caretLeft: 2,
   };

--- a/packages/ui-contract-editor/src/lib/styles.css
+++ b/packages/ui-contract-editor/src/lib/styles.css
@@ -56,7 +56,10 @@ a {
     color: #FFFFFF;
     padding: 1px 3px;
     position: absolute;
+    z-index:10000;		
 }
+
+
 
 .conditionalIcon,
 .optionalIcon {


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> The z-index of optionaltooltip was set to 1000 so that it does not come under the clause buttons




### Author Checklist
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions