### PR TITLE
fix(ui-markdown-editor): close hyperlink modal when not interacting i47

### DIFF
--- a/packages/ui-markdown-editor/src/lib/index.js
+++ b/packages/ui-markdown-editor/src/lib/index.js
@@ -95,6 +95,8 @@ export const MarkdownEditor = (props) => {
         hotkeyActions[type](code);
       }
     });
+
+    setShowLinkModal(false);
   }, [canBeFormatted, canKeyDown, editor, hotkeyActions]);
 
   const onBeforeInput = useCallback((event) => {


### PR DESCRIPTION
Signed-off-by: Yang Wei Hao <whyang0808@gmail.com>

# Issue #47 

### Changes
- fix(ui-markdown-editor): close hyperlink modal when user is not interacting with it