### PR TITLE
fix(ui-markdown-editor): Fix flashing at style format - 97

### DIFF
--- a/packages/ui-markdown-editor/src/lib/FormattingToolbar/StyleFormat/index.js
+++ b/packages/ui-markdown-editor/src/lib/FormattingToolbar/StyleFormat/index.js
@@ -1,8 +1,7 @@
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Node } from 'slate';
-import { useSlate } from 'slate-react';
+import { useEditor } from 'slate-react';
 import { Dropdown } from 'semantic-ui-react';
 import StyleDropdownItem from './Item';
 import {
@@ -17,7 +16,7 @@ import {
 } from '../../utilities/schema';
 
 const StyleDropdown = ({ canBeFormatted }) => {
-  const editor = useSlate();
+  const editor = useEditor();
   const currentBlock = (editor && editor.selection)
     ? BLOCK_STYLE[Node.parent(editor, editor.selection.focus.path).type]
     : 'Style';
@@ -60,6 +59,5 @@ const StyleDropdown = ({ canBeFormatted }) => {
 StyleDropdown.propTypes = {
   canBeFormatted: PropTypes.func
 };
-
 
 export default StyleDropdown;


### PR DESCRIPTION
Signed-off-by: Sahal Saad <caalshift@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #97 <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Fix flashing at style format

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- I am not sure why previously use `useSlate`. Cannot trace from git history.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #<NUMBER>
- Pull Request #<NUMBER>

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
