### PR TITLE
style(ui-markdown-editor): remove link modal fade-in effect - I218

### DIFF
--- a/packages/ui-markdown-editor/src/FormattingToolbar/HyperlinkModal.js
+++ b/packages/ui-markdown-editor/src/FormattingToolbar/HyperlinkModal.js
@@ -24,8 +24,6 @@ const HyperlinkWrapper = styled.div`
     background-color: #FFFFFF;
     border: 1px solid #d4d4d5;
     border-radius: .3rem;
-    transition: opacity 0.75s;
-
     min-width:300px;
     line-height: 1.4285em;
     max-width: 250px;


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #218  <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE>Removed the transition property in hyperlink modal styles

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE> The Modal will now no longer appear via transition and will appear instantly

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
