### PR TITLE
fix(main): deprecated uuid import fix - I224

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,13 @@
 				"slash": "3.0.0",
 				"uuid": "3.3.2",
 				"xregexp": "4.2.4"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+				}
 			}
 		},
 		"@accordproject/concerto-core": {
@@ -62,6 +69,11 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 				}
 			}
 		},
@@ -192,6 +204,13 @@
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",
 				"uuid": "3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+				}
 			}
 		},
 		"@accordproject/markdown-transform": {
@@ -9453,11 +9472,6 @@
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
-		"@types/uuid": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
-			"integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
-		},
 		"@types/vfile": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
@@ -9799,6 +9813,13 @@
 						"log-symbols": "^2.1.0",
 						"loglevelnext": "^1.0.1",
 						"uuid": "^3.1.0"
+					},
+					"dependencies": {
+						"uuid": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+							"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+						}
 					}
 				}
 			}
@@ -11805,6 +11826,13 @@
 				"better-queue-memory": "^1.0.1",
 				"node-eta": "^0.9.0",
 				"uuid": "^3.0.0"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
 			}
 		},
 		"better-queue-memory": {
@@ -27888,6 +27916,11 @@
 								"psl": "^1.1.28",
 								"punycode": "^2.1.1"
 							}
+						},
+						"uuid": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+							"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 						}
 					}
 				},
@@ -39466,6 +39499,13 @@
 					"requires": {
 						"faye-websocket": "^0.10.0",
 						"uuid": "^3.0.1"
+					},
+					"dependencies": {
+						"uuid": {
+							"version": "3.4.0",
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+							"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+						}
 					}
 				},
 				"sockjs-client": {
@@ -41177,6 +41217,11 @@
 						"psl": "^1.1.24",
 						"punycode": "^1.4.1"
 					}
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 				}
 			}
 		},
@@ -44364,6 +44409,12 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -45596,25 +45647,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-		},
-		"uuidv4": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.3.tgz",
-			"integrity": "sha512-4hxGisl76Y6A7nkadg5gMrPGVYVGLmJ3fZHVvmnXsy+8DMA7n7YV/4Y72Fw38CCwpZpyPgOaa/4YxhkCYwyNNQ==",
-			"requires": {
-				"@types/uuid": "8.3.0",
-				"uuid": "8.3.0"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-					"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
-				}
-			}
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "1.1.2",
@@ -46466,6 +46501,13 @@
 			"requires": {
 				"ansi-colors": "^3.0.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
 			}
 		},
 		"webpack-manifest-plugin": {

--- a/packages/storybook/src/stories/4-ContractEditor.stories.js
+++ b/packages/storybook/src/stories/4-ContractEditor.stories.js
@@ -18,7 +18,7 @@ import { storiesOf } from '@storybook/react'
 import { Editor, Node, Transforms } from 'slate';
 
 /* Misc */
-import { uuid } from 'uuidv4';
+import { v4 as uuidv4 } from 'uuid';
 import styled from 'styled-components';
 
 const slateTransformer = new SlateTransformer();
@@ -110,7 +110,7 @@ export const contractEditor = () => {
               children: slateValueNew.document.children,
               data: {
                 src: templateUrl,
-                name: uuid(),
+                name: uuidv4(),
               },
               object: 'block',
               type: 'clause',

--- a/packages/ui-contract-editor/package-lock.json
+++ b/packages/ui-contract-editor/package-lock.json
@@ -1348,9 +1348,9 @@
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 				},
 				"uuid": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 				},
 				"verror": {
 					"version": "1.10.0",

--- a/packages/ui-contract-editor/package.json
+++ b/packages/ui-contract-editor/package.json
@@ -3,10 +3,10 @@
   "version": "0.96.1",
   "private": false,
   "dependencies": {
+    "@accordproject/markdown-cicero": "^0.12.12",
     "@accordproject/markdown-html": "^0.12.12",
     "@accordproject/markdown-slate": "^0.12.12",
     "@accordproject/markdown-transform": "^0.12.12",
-    "@accordproject/markdown-cicero": "^0.12.12",
     "@accordproject/ui-markdown-editor": "0.96.1",
     "@babel/runtime": "^7.10.3",
     "lodash": "^4.17.15",
@@ -14,7 +14,7 @@
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.88.2",
     "slate-history": "^0.58.4",
-    "uuidv4": "^6.0.8"
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/ui-contract-editor/rollup.config.js
+++ b/packages/ui-contract-editor/rollup.config.js
@@ -43,7 +43,7 @@ const config = outputs.map(({ file, format }) => ({
       'styled-components': 'styled',
       slate: 'slate',
       'slate-react': 'slateReact',
-      uuidv4: 'uuidv4',
+      uuid: 'v4 as uuidv4',
       '@accordproject/markdown-slate': 'markdownSlate',
       '@accordproject/markdown-html': 'markdownHtml',
       lodash: '_',

--- a/packages/ui-contract-editor/src/ContractEditor/plugins/withClauses.js
+++ b/packages/ui-contract-editor/src/ContractEditor/plugins/withClauses.js
@@ -1,4 +1,4 @@
-import { uuid } from 'uuidv4';
+import { v4 as uuidv4 } from 'uuid';
 import { Editor, Node, Transforms, Path } from 'slate';
 import { HistoryEditor } from 'slate-history';
 
@@ -179,7 +179,7 @@ const withClauses = (editor, withClausesProps) => {
         const NEW_SLATE_CHILDREN = SLATE_DOM.document.children.map(
           (child) => {
             if (child.type === CLAUSE) {
-              child.data.clauseid = uuid();
+              child.data.clauseid = uuidv4();
               clausesToParseAndPaste.push(child);
             }
             return child;


### PR DESCRIPTION
Signed-off-by: K-Kumar01 <kushalkumargupta4@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #224  <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Fixed the deprecated uuid import. 
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Deprecated uuid import resolved.
- <TWO> No warning logged in the console.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- <ONE> uuid deprecated import issue resolved

<!--- ### Screenshots or Video --->
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
