### PR TITLE
fix(ui-contract-editor): prevent clause drag and drop in list - I157

### DIFF
--- a/packages/ui-contract-editor/src/ContractEditor/index.js
+++ b/packages/ui-contract-editor/src/ContractEditor/index.js
@@ -207,14 +207,17 @@ const ContractEditor = (props) => {
     if (!clauseNodeAndPath) return true; // continue to next handler if not a clause
     const node = ReactEditor.toSlateNode(editor, event.target);
     const path = ReactEditor.findPath(editor, node);
-
     const nodes = [...Node.ancestors(editor, path, { reverse: false })];
+    //placementNodeType is used store node type and used to compare if a node is a list or not.
     const placementNodeType = nodes.length > 1 ? nodes[1][0].type : null;
     if(placementNodeType === "ul_list" || placementNodeType === "ol_list"){
+      //Node of type List stored in placementNode and its path in placementNodepath
       const placementNode = nodes[1][0];
       const placementNodePath = ReactEditor.findPath(editor, placementNode);
       const listSize=nodes[1][0].children.length;
+      //currentNodeIndex cpatures the list-item index
       const currentNodeIndex=nodes[2][1][1];
+      //comparison to decide to place it above or below the list
       if(listSize/2 > currentNodeIndex){
         if(clauseNodeAndPath[1] > placementNodePath[0]){
           Transforms.moveNodes(editor, { at: clauseNodeAndPath[1], to: placementNodePath });

--- a/packages/ui-contract-editor/src/ContractEditor/index.js
+++ b/packages/ui-contract-editor/src/ContractEditor/index.js
@@ -209,7 +209,27 @@ const ContractEditor = (props) => {
     const path = ReactEditor.findPath(editor, node);
 
     const nodes = [...Node.ancestors(editor, path, { reverse: false })];
-    // first node is root editor so second will be top level after root editor
+    const placementNodeType = nodes.length > 1 ? nodes[1][0].type : null;
+    if(placementNodeType === "ul_list" || placementNodeType === "ol_list"){
+      const placementNode = nodes[1][0];
+      const placementNodePath = ReactEditor.findPath(editor, placementNode);
+      const listSize=nodes[1][0].children.length;
+      const currentNodeIndex=nodes[2][1][1];
+      if(listSize/2 > currentNodeIndex){
+        if(clauseNodeAndPath[1] > placementNodePath[0]){
+          Transforms.moveNodes(editor, { at: clauseNodeAndPath[1], to: placementNodePath });
+        }else{
+          Transforms.moveNodes(editor, { at: clauseNodeAndPath[1], to: [placementNodePath[0] - 1] });
+        }
+      }else{
+        if(clauseNodeAndPath[1] > placementNodePath[0]){
+          Transforms.moveNodes(editor, { at: clauseNodeAndPath[1], to: [placementNodePath[0] + 1] });
+        }else{
+          Transforms.moveNodes(editor, { at: clauseNodeAndPath[1], to: placementNodePath });
+        }
+      }
+    }else{
+      // first node is root editor so second will be top level after root editor
     const topLevelNodeAndPath = nodes[1];
     // if no top level after editor then the node was already a top level node so use its own path
     const topLevelPath = topLevelNodeAndPath ? topLevelNodeAndPath[1] : path;
@@ -237,6 +257,7 @@ const ContractEditor = (props) => {
     Transforms.collapse(editor, { edge });
     Transforms.removeNodes(editor, { at: sourceRange.anchor.path, match: n => n.type === CLAUSE });
     Transforms.insertNodes(editor, clauseNodeAndPath[0]);
+    }
     return false;
   };
 


### PR DESCRIPTION
…list - #157

Signed-off-by: User <shevkar.sanket@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #157 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Drag and Drop possible for both:
- Inside The List: 'edge' = focus, Transform.select(editor, targetRange)
- Oustside The List: Only able to place above the list, selects the previous child component using Transform.select, 'edge'=end


### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- When dropping outside the list the drag and drop icon/cursor of the clause should be placed after the list-item text.
- When dropping inside the list the drag and drop icon/cursor of the clause should be placed at the start of the list-item text.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
-Demo Outside the list: https://www.loom.com/share/954e26d39c114443a2057c6a082e9088
-Demo Inside the list: https://www.loom.com/share/0b52426ebd154db8958adf5c7a0822ad

### Related Issues
- Issue #157 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
