### PR TITLE
Issue #184 solved  - Long Template Name intersects with Logo

### DIFF
--- a/packages/ui-components/src/Library/Components/LibraryItemCard.js
+++ b/packages/ui-components/src/Library/Components/LibraryItemCard.js
@@ -15,10 +15,10 @@ const cardStyle = {
 };
 
 const itemLogoStyle = {
-  display: "inline-block",
-  objectFit: "contain",
   maxHeight: "20px",
   float: "right",
+  display: "inline-block",
+  objectFit: "contain",
 };
 
 const DescriptionContainer = styled(Card.Description)``;

--- a/packages/ui-components/src/Library/Components/LibraryItemCard.js
+++ b/packages/ui-components/src/Library/Components/LibraryItemCard.js
@@ -15,10 +15,10 @@ const cardStyle = {
 };
 
 const itemLogoStyle = {
-  objectFit: "contain",
-  float: "right",
-  maxHeight: "20px",
   display: "inline-block",
+  objectFit: "contain",
+  maxHeight: "20px",
+  float: "right",
 };
 
 const DescriptionContainer = styled(Card.Description)``;

--- a/packages/ui-components/src/Library/Components/LibraryItemCard.js
+++ b/packages/ui-components/src/Library/Components/LibraryItemCard.js
@@ -1,60 +1,58 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { Card, Image } from 'semantic-ui-react';
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { Card, Image } from "semantic-ui-react";
 
-import CardActions from './CardActions';
+import CardActions from "./CardActions";
 
 const cardStyle = {
-  margin: '10px 0',
-  border: '1px solid #7B8084',
-  borderRadius: '6px',
-  backgroundColor: '#fff',
-  textAlign: 'left',
-  boxShadow: '0 1px 9px 0 rgba(0,0,0,0.1)',
+  margin: "10px 0",
+  border: "1px solid #7B8084",
+  borderRadius: "6px",
+  backgroundColor: "#fff",
+  textAlign: "left",
+  boxShadow: "0 1px 9px 0 rgba(0,0,0,0.1)",
 };
 
 const itemLogoStyle = {
-  position: 'absolute',
-  top: '13px',
-  right: '16px',
-  maxHeight: '23px',
+  objectFit: "contain",
+  float: "right",
+  maxHeight: "20px",
+  display: "inline-block",
 };
 
-const DescriptionContainer = styled(Card.Description)`
-`;
+const DescriptionContainer = styled(Card.Description)``;
 
 /**
  * A Library Item Card component that displays each library item and it's details.
  */
-const LibraryItemCard = props => (
+const LibraryItemCard = (props) => (
+
   <Card
     fluid
     key={props.item.uri}
     style={cardStyle}
     className={`ui-components__library-card ${props.item.itemType}`}
   >
-    <Card.Content className='ui-components__library-card-content'>
+    <Card.Content className="ui-components__library-card-content">
       <Image
         style={itemLogoStyle}
         src={props.item.logoUrl}
-        className='ui-components__library-card-logo'
+        className="ui-components__library-card-logo"
       />
-      <Card.Header className='ui-components__library-card-header'>
-        { props.item.displayName || props.item.name }
+      <Card.Header className="ui-components__library-card-header">
+        {props.item.displayName || props.item.name}
       </Card.Header>
-      <Card.Meta className='ui-components__library-card-meta'>
-        <span className='ui-components__library-card-item-type'>
+      <Card.Meta className="ui-components__library-card-meta">
+        <span className="ui-components__library-card-item-type">
           {props.itemTypeName}
         </span>
         &nbsp;|&nbsp;
-        <span className='ui-components__library-card-item-version'>
+        <span className="ui-components__library-card-item-version">
           Version {props.item.version}
         </span>
       </Card.Meta>
-      <DescriptionContainer>
-        {props.item.description}
-      </DescriptionContainer>
+      <DescriptionContainer>{props.item.description}</DescriptionContainer>
     </Card.Content>
     <CardActions
       item={props.item}

--- a/packages/ui-components/src/Library/index.js
+++ b/packages/ui-components/src/Library/index.js
@@ -128,6 +128,8 @@ const LibraryComponent = (props) => {
     return filtered;
   }, [query, props.items, itemTypeFilter]);
 
+    
+
   const renderItemTypeFilter = useCallback(() => {
     if (props.itemTypes.length === 1) return null;
 
@@ -174,8 +176,10 @@ const LibraryComponent = (props) => {
       </Functionality>
       <LibraryItemCards className="ui-components__library-cards-wrapper">
         {
+          
           filtered.length
             ? filtered.map(item => (
+                
                 <LibraryItemCard
                   key={item.uri}
                   item={item}


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #184
<!--- Provide an overall summary of the pull request -->

This pull request solves the mentioned issue by changing the CSS styling of logo  in ' LibraryItemCard.js ' .

### Changes

This issue is solved by changing ' itemLogoStyle ' in ' LibraryItemCard.js ' : 

 NOW ->  

const itemLogoStyle = {
  maxHeight: "20px",
  float: "right",
  display: "inline-block",
  objectFit: "contain",
};

INITIALLY ->

 const itemLogoStyle = {
  position: 'absolute',
  top: '13px',
  right: '16px',
  maxHeight: '23px',
};

Now if , logo src property  is passed to Image component then logo will be visible and text will be wrapped around logo as shown in screenshot .

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->

Logo src property must passed as a props to Image component to see the changes . 
 

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

![Screenshot (11)_LI](https://user-images.githubusercontent.com/54985099/104123808-3cb87c80-5373-11eb-9dbf-e637197215ea.jpg)


### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
