### PR TITLE
feat(ui-markdown-editor): center align h1 tags - I146

### DIFF
--- a/packages/ui-markdown-editor/src/utilities/constants.js
+++ b/packages/ui-markdown-editor/src/utilities/constants.js
@@ -39,6 +39,7 @@ export const DROPDOWN_STYLE_H1 = {
   lineHeight: '23px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
   color: MISC_CONSTANTS.DROPDOWN_COLOR,
+  textAlign: 'center',
 };
 
 export const DROPDOWN_STYLE_H2 = {
@@ -56,22 +57,22 @@ export const DROPDOWN_STYLE_H3 = {
 };
 
 export const DROPDOWN_STYLE_H4 = {
-  fontSize: '14px',
-  lineHeight: '14px',
+  fontSize: '15px',
+  lineHeight: '15px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
   color: MISC_CONSTANTS.DROPDOWN_COLOR,
 };
 
 export const DROPDOWN_STYLE_H5 = {
-  fontSize: '12px',
-  lineHeight: '12px',
+  fontSize: '14x',
+  lineHeight: '14px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
   color: MISC_CONSTANTS.DROPDOWN_COLOR,
 };
 
 export const DROPDOWN_STYLE_H6 = {
-  fontSize: '10px',
-  lineHeight: '10px',
+  fontSize: '13px',
+  lineHeight: '13px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
   color: MISC_CONSTANTS.DROPDOWN_COLOR,
 };


### PR DESCRIPTION
Signed-off-by: Udbhavbisarya23 <udbhavbisarya46.ub@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #146 
<!--- Provide an overall summary of the pull request -->
Changed Heading and Made changes to font sizes of ui-markdown-editor
### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Center Aligned the H1 tags
- Changed font size and line height of h4,h5 and h6tags to 15,14 and 13 px respectively (As it is in PDF)

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![img](https://user-images.githubusercontent.com/43880582/107266964-41ed1200-6a6c-11eb-9167-5cc59ec2bd5b.jpeg)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
