### PR TITLE
feat(ui-contract-editor):string variable can be made empty(#150)

### DIFF
--- a/packages/ui-contract-editor/src/ContractEditor/plugins/withVariables.js
+++ b/packages/ui-contract-editor/src/ContractEditor/plugins/withVariables.js
@@ -57,16 +57,15 @@ export const isEditableVariable = (lockText, editor, event) => {
   const textLength = Node.get(editor, editor.selection.focus.path).text.length;
   const atEnd = editor => textLength === editor.selection.focus.offset;
   const editable = inVariable(editor) && !inReadOnlyVariable(editor);
-
   if (editable) {
     if (atEnd(editor) && event.inputType === 'deleteContentForward') {
       return false;
     }
     if (event.inputType === 'deleteContentBackward') {
       // Do not allow user to delete variable if only 1 char left
-      if (textLength === 1) {
-        return false;
-      }
+      // if (textLength === 1) {
+      //   return false;
+      // }
       // if we hit backspace and are at the zeroth position of a
       // variable prevent deleting the char that precedes the variable
       return selection.anchor.offset > 0;

--- a/packages/ui-contract-editor/src/ContractEditor/plugins/withVariables.js
+++ b/packages/ui-contract-editor/src/ContractEditor/plugins/withVariables.js
@@ -62,10 +62,6 @@ export const isEditableVariable = (lockText, editor, event) => {
       return false;
     }
     if (event.inputType === 'deleteContentBackward') {
-      // Do not allow user to delete variable if only 1 char left
-      // if (textLength === 1) {
-      //   return false;
-      // }
       // if we hit backspace and are at the zeroth position of a
       // variable prevent deleting the char that precedes the variable
       return selection.anchor.offset > 0;


### PR DESCRIPTION
Signed-off-by: User <shevkar.sanket@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #150 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Code commented in isEditableVariable in withVariables.js

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
[https://www.loom.com/share/91e95c6d657e40d48d41cf41e2da0812](url)

### Related Issues
- Issue #150

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
