### PR TITLE
feat(ui-contract-editor):disable cursor caret for read-only text

### DIFF
--- a/packages/ui-contract-editor/src/components/styles.js
+++ b/packages/ui-contract-editor/src/components/styles.js
@@ -103,6 +103,7 @@ export const ClauseBody = styled.div`
   color: #141F3C;
   font-size: 1em;
   line-height: 22px;
+  caret-color: transparent;
 `;
 
 export const ClauseIcon = styled.svg`

--- a/packages/ui-contract-editor/src/styles.css
+++ b/packages/ui-contract-editor/src/styles.css
@@ -33,6 +33,7 @@ a {
     padding: 0px 3px;
     border-radius: 2px;
     background-color: #fff;
+    caret-color: black;
 }
 
 .formula {   


### PR DESCRIPTION
Signed-off-by: User <shevkar.sanket@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #248 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- `caret-color` set for variales and clause-body

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- Cursor caret for read-only variables is still active.

### Related Issues
- Issue #248 
- Pull Request #<NUMBER>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
