### PR TITLE
feat(ui-contract-editor):drag&drop disabled for embeded clauses

### DIFF
--- a/packages/ui-contract-editor/src/components/Clause/index.js
+++ b/packages/ui-contract-editor/src/components/Clause/index.js
@@ -115,7 +115,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
         className={`ui-contract-editor__clause ${props.error ? 'error' : ''}`}
         onMouseEnter={() => setHovering(true)}
         onMouseLeave={() => setHovering(false)}
-        style={{ userSelect: `${props.readOnly?"text":"none"}` padding: '3px'}}
+        style={{ userSelect: `${props.readOnly?"text":"none"}`, padding: '3px'}}
         draggable="true"
         ref={ref}
         error={props.error}

--- a/packages/ui-contract-editor/src/components/Clause/index.js
+++ b/packages/ui-contract-editor/src/components/Clause/index.js
@@ -115,7 +115,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
         className={`ui-contract-editor__clause ${props.error ? 'error' : ''}`}
         onMouseEnter={() => setHovering(true)}
         onMouseLeave={() => setHovering(false)}
-        style={{ userSelect: `${props.readOnly?"text":"none" padding: '3px'}`}}
+        style={{ userSelect: `${props.readOnly?"text":"none"}` padding: '3px'}}
         draggable="true"
         ref={ref}
         error={props.error}

--- a/packages/ui-contract-editor/src/components/Clause/index.js
+++ b/packages/ui-contract-editor/src/components/Clause/index.js
@@ -154,7 +154,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
             {header}
           </S.HeaderToolTipText>
         </S.ClauseHeader>
-        { (!props.readOnly)
+        {!props.readOnly
           && header.length !== 0 ? <>
               <S.DragWrapper
                 {...iconWrapperProps}

--- a/packages/ui-contract-editor/src/components/Clause/index.js
+++ b/packages/ui-contract-editor/src/components/Clause/index.js
@@ -42,7 +42,6 @@ const ClauseComponent = React.forwardRef((props, ref) => {
 
   const title = titleGenerator(props.templateUri);
   const header = headerGenerator(props.templateUri, clauseProps.HEADER_TITLE);
-
   const iconWrapperProps = {
     currentHover: hovering,
     contentEditable: false,
@@ -116,7 +115,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
         className={`ui-contract-editor__clause ${props.error ? 'error' : ''}`}
         onMouseEnter={() => setHovering(true)}
         onMouseLeave={() => setHovering(false)}
-        style={{ userSelect: 'none' }}
+        style={{ userSelect: 'none', padding: '3px' }}
         draggable="true"
         ref={ref}
         error={props.error}
@@ -155,8 +154,8 @@ const ClauseComponent = React.forwardRef((props, ref) => {
             {header}
           </S.HeaderToolTipText>
         </S.ClauseHeader>
-        { !props.readOnly
-          && <>
+        { (!props.readOnly)
+          && header.length !== 0 ? <>
               <S.DragWrapper
                 {...iconWrapperProps}
               >
@@ -236,7 +235,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
                 </S.HeaderToolTipWrapper>
               }
             </S.DeleteWrapper>
-          </>
+          </> : null
         }
         <S.ClauseBody
           onMouseEnter={(e) => setDraggable(e, false)}


### PR DESCRIPTION
Signed-off-by: User <shevkar.sanket@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #178 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- String match with clause header, if header length is 0 then disable the clause ui-icons.
- padding added to clause wrapper

### Related Issues
- Issue #178 
### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
