### PR TITLE
fix(ui-markdown-editor):multi-para to list proper indent - I158

### DIFF
--- a/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
@@ -42,6 +42,10 @@ export const toggleBlock = (editor, format) => {
       const listItemBlock = { type: LIST_ITEM, children: [], data: { tight: true } };
       const anchor = editor.selection.anchor.path.slice(0, -1).concat(0, editor.selection.anchor.path[editor.selection.anchor.path.length - 1]);
       const focus = editor.selection.focus.path.slice(0, -1).concat(0, editor.selection.focus.path[editor.selection.focus.path.length - 1]);
+
+      if(anchor[1]>focus[1]){
+        [anchor[1],focus[1]]=[focus[1],anchor[1]];
+      }
       // eslint-disable-next-line no-restricted-syntax
       for (const [node, path] of Node.descendants(
         editor,

--- a/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
@@ -42,7 +42,7 @@ export const toggleBlock = (editor, format) => {
       const listItemBlock = { type: LIST_ITEM, children: [], data: { tight: true } };
       const anchor = editor.selection.anchor.path.slice(0, -1).concat(0, editor.selection.anchor.path[editor.selection.anchor.path.length - 1]);
       const focus = editor.selection.focus.path.slice(0, -1).concat(0, editor.selection.focus.path[editor.selection.focus.path.length - 1]);
-
+      // swap anchor and focus when selecting from bottom-top
       if(anchor[1]>focus[1]){
         [anchor[1],focus[1]]=[focus[1],anchor[1]];
       }


### PR DESCRIPTION
Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #158 
Choosing multiple paragraphs and then converting them to list will now show points-bullet or numbers along with the indentation

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Need to change the anchor and focus when selecting from bottom

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
Selecting from bottom
![Screenshot from 2021-02-20 23-49-03](https://user-images.githubusercontent.com/59891164/108604993-2ae8e100-73d7-11eb-9379-0ecd143f6045.png)
Result
![Screenshot from 2021-02-20 23-49-10](https://user-images.githubusercontent.com/59891164/108604994-2d4b3b00-73d7-11eb-9b1d-40289d4fd192.png)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
