### PR TITLE
fix(ui-markdown-editor): list formatting is preserved in headings

### DIFF
--- a/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
@@ -1,6 +1,6 @@
 import { Node, Editor, Transforms } from 'slate';
 import {
-  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH
+  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH, HEADINGS
 } from './schema';
 
 export const isBlockActive = (editor, format) => {
@@ -42,12 +42,13 @@ export const toggleBlock = (editor, format) => {
       const listItemBlock = { type: LIST_ITEM, children: [], data: { tight: true } };
       const anchor = editor.selection.anchor.path.slice(0, -1).concat(0, editor.selection.anchor.path[editor.selection.anchor.path.length - 1]);
       const focus = editor.selection.focus.path.slice(0, -1).concat(0, editor.selection.focus.path[editor.selection.focus.path.length - 1]);
+      
       // eslint-disable-next-line no-restricted-syntax
       for (const [node, path] of Node.descendants(
         editor,
         { from: anchor, to: focus }
       )) {
-        if (node.type === PARAGRAPH) {
+        if (node.type === PARAGRAPH  || HEADINGS.includes(node.type)) {
           Transforms.wrapNodes(editor, listItemBlock, { at: path });
         }
       }


### PR DESCRIPTION
Signed-off-by: Gatij Taranekar <gatij.taranekar@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #54 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Added another condition for checking node type as headings in the if block.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
https://www.loom.com/share/a417c8136e954883b281c8b1e74fe254

### Related Issues
- Issue #158 
- Pull Request #252 

### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
