### PR TITLE
bug(ui-contract-editor): remove z-index of toolbar - I87

### DIFF
--- a/packages/ui-markdown-editor/src/FormattingToolbar/ToolbarMenu.js
+++ b/packages/ui-markdown-editor/src/FormattingToolbar/ToolbarMenu.js
@@ -8,7 +8,6 @@ const Menu = styled.div`
   min-width: 600px;
   background-color: #FFF;
   padding: 15px 15px 5px 15px;
-  z-index: 10;
   display: flex;
   align-content: space-evenly;
   justify-content: center;


### PR DESCRIPTION
Signed-off-by: Udbhavbisarya23 <udbhavbisarya46.ub@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #87 
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> The z-index of the formatting toolbar is changed from 10. No z-index assigned

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![WhatsApp Image 2021-02-26 at 10 55 45](https://user-images.githubusercontent.com/43880582/109259915-27b08380-7823-11eb-91dc-2c8b2316df71.jpeg)


### Related Issues
- Issue #87 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
