### PR TITLE
fix(ui-markdown-editor): linebreak - #263, #267, #269

### DIFF
--- a/packages/ui-markdown-editor/src/components/index.js
+++ b/packages/ui-markdown-editor/src/components/index.js
@@ -7,7 +7,7 @@ import { HorizontalRule } from './Span';
 import {
   PARAGRAPH, LINK, IMAGE, H1, H2, H3, H4, H5, H6, HR,
   CODE_BLOCK, HTML_BLOCK, BLOCK_QUOTE, UL_LIST, OL_LIST, LIST_ITEM,
-  HTML_INLINE, SOFTBREAK, LINEBREAK, HEADINGS
+  HTML_INLINE, HEADINGS, LINEBREAK, PARAGRAPH_BREAK
 } from '../utilities/schema';
 import {
   H1_STYLING,
@@ -40,11 +40,13 @@ const Element = (props) => {
     [H4]: () => (<Heading id={headingId} as="h4" style={H4_STYLING} {...attributes}>{children}</Heading>),
     [H5]: () => (<Heading id={headingId} as="h5" style={H5_STYLING} {...attributes}>{children}</Heading>),
     [H6]: () => (<Heading id={headingId} as="h6" style={H6_STYLING} {...attributes}>{children}</Heading>),
-    [SOFTBREAK]: () => (<span className={SOFTBREAK} {...attributes}> {children}</span>),
     [LINEBREAK]: () => (<span {...attributes}>
       <span contentEditable={false} style={{ userSelect: 'none' }}>
         <br />
       </span>
+      {children}
+    </span>),
+    [PARAGRAPH_BREAK]: () => (<span {...attributes}>
       {children}
     </span>),
     [LINK]: () => (<a {...attributes} href={data.href}>{children}</a>),

--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -1,6 +1,4 @@
-import React, {
-  useCallback, useMemo, useState
-} from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { CiceroMarkTransformer } from '@accordproject/markdown-cicero';
 import { HtmlTransformer } from '@accordproject/markdown-html';
 import { SlateTransformer } from '@accordproject/markdown-slate';
@@ -14,14 +12,16 @@ import { BUTTON_ACTIVE, BLOCK_STYLE } from './utilities/constants';
 import withSchema from './utilities/schema';
 import Element from './components';
 import Leaf from './components/Leaf';
-import { toggleMark, toggleBlock, insertThematicBreak,
-  insertLinebreak, insertHeadingbreak, isBlockHeading } from './utilities/toolbarHelpers';
+import { toggleMark, toggleBlock, insertThematicBreak, 
+  insertLineBreak, isBlockHeading, insertHeadingBreak, insertParagraphBreak
+} from './utilities/toolbarHelpers';
 import { withImages, insertImage } from './plugins/withImages';
 import { withLinks, isSelectionLinkBody } from './plugins/withLinks';
 import { withHtml } from './plugins/withHtml';
 import { withLists } from './plugins/withLists';
 import FormatBar from './FormattingToolbar';
 import { withText } from './plugins/withText';
+import { HEADINGBREAK } from './utilities/schema';
 
 export const markdownToSlate = (markdown) => {
   const slateTransformer = new SlateTransformer();
@@ -85,8 +85,9 @@ export const MarkdownEditor = (props) => {
       setShowLinkModal(true);
     },
     horizontal_rule: (code) => insertThematicBreak(editor, code),
-    linebreak: (code) => insertLinebreak(editor, code),
-    headingbreak: () => insertHeadingbreak(editor)
+    linebreak: () => insertLineBreak(editor),
+    paragraph_break: () => insertParagraphBreak(editor),
+    headingbreak: () => insertHeadingBreak(editor)
   };
 
   /**
@@ -118,15 +119,17 @@ export const MarkdownEditor = (props) => {
       return;
     }
 
-    if (event.key === 'Enter' && !isBlockHeading(editor)) {
-      return;
-    }
-
     const hotkeys = Object.keys(HOTKEYS);
     hotkeys.forEach((hotkey) => {
       if (isHotkey(hotkey, event)) {
         event.preventDefault();
         const { code, type } = HOTKEYS[hotkey];
+        // if linebreak happens form a heading block then we run the insertHeadingBreak function
+        // otherwise it would be a linebreak every time
+        if(type === 'paragraph_break' && isBlockHeading(editor)){
+          hotkeyActions[HEADINGBREAK]()
+          return;
+        }
         hotkeyActions[type](code);
       }
     });

--- a/packages/ui-markdown-editor/src/utilities/hotkeys.js
+++ b/packages/ui-markdown-editor/src/utilities/hotkeys.js
@@ -1,7 +1,7 @@
 import {
   LINK, IMAGE, BLOCK_QUOTE, UL_LIST, OL_LIST,
   MARK_BOLD, MARK_ITALIC, MARK_CODE, HR, LINEBREAK,
-  HEADINGBREAK
+  PARAGRAPH_BREAK
 } from './schema';
 
 const HOTKEYS = {
@@ -54,8 +54,8 @@ const HOTKEYS = {
     code: LINEBREAK,
   },
   'enter': {
-    type: 'headingbreak',
-    code: HEADINGBREAK
+    type: 'paragraph_break',
+    code: PARAGRAPH_BREAK,
   }
 };
 

--- a/packages/ui-markdown-editor/src/utilities/schema.js
+++ b/packages/ui-markdown-editor/src/utilities/schema.js
@@ -24,6 +24,7 @@ export const MARKS = [MARK_BOLD, MARK_ITALIC, MARK_CODE, MARK_HTML];
 
 export const HR = 'horizontal_rule';
 export const SOFTBREAK = 'softbreak';
+export const PARAGRAPH_BREAK = 'paragraph_break';
 export const LINEBREAK = 'linebreak';
 export const LINK = 'link';
 export const IMAGE = 'image';
@@ -33,12 +34,14 @@ export const HEADINGBREAK = 'headingbreak';
 const INLINES = {
   [LINEBREAK]: true,
   [SOFTBREAK]: true,
+  [PARAGRAPH_BREAK]: true,
   [HTML_INLINE]: true,
   [LINK]: true,
   [IMAGE]: true,
 };
 const VOIDS = {
   [LINEBREAK]: true,
+  [PARAGRAPH_BREAK]: true,
   [SOFTBREAK]: true,
   [IMAGE]: true,
   [HR]: true,

--- a/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
@@ -175,6 +175,7 @@ export const insertHeadingbreak = (editor) => {
   const text = { object: 'text', text: '' };
   const n = { object: "block", type: 'paragraph', children: [text] };
   Transforms.insertNodes(editor, n);
+  Transforms.move(editor, { distance: 1, unit: 'character' })
   return;
 }
 

--- a/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
@@ -1,6 +1,6 @@
 import { Node, Editor, Transforms } from 'slate';
 import {
-  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH, HEADINGS, H1, H2, H3, H4, H5, H6
+  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH, LINEBREAK, HEADINGS, H1, H2, H3, H4, H5, H6
 } from './schema';
 
 /**
@@ -159,23 +159,27 @@ export const insertThematicBreak = (editor, type) => {
  * @param {Object} editor Editor to be transformed
  * @param {string} format Type of the break
  */
-export const insertLinebreak = (editor, type) => {
+export const insertLineBreak = (editor, type) => {
   const text = { object: 'text', text: '' };
-  const br = { type, children: [text], data: {} };
+  const br = { type: LINEBREAK, children: [text], data: {} };
   Transforms.insertNodes(editor, br);
   Transforms.move(editor, { distance: 1, unit: 'character' });
 };
+
+export const insertParagraphBreak = (editor) => {
+  editor.insertBreak();
+  return;
+}
 
 /**
  * Inserts a heading break in the document.
  * 
  * @param {Object} editor Editor to be transformed
  */
-export const insertHeadingbreak = (editor) => {
+export const insertHeadingBreak = (editor) => {
   const text = { object: 'text', text: '' };
   const n = { object: "block", type: 'paragraph', children: [text] };
   Transforms.insertNodes(editor, n);
-  Transforms.move(editor, { distance: 1, unit: 'character' })
   return;
 }
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #263 #267
<!--- Provide an overall summary of the pull request -->

## Update
**_This was my thought process of finding the problem and the solution._**

## Identifying the problem

 - As you can see [here](https://github.com/accordproject/web-components/blob/b6ccb71ca4e103d5c699ad4395653d55597f3919/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js#L98), we do not have any function for the ``softbreak``.
 - The functions that exist there are ``insertLinebreak`` and ``insertHeadingbreak``. 



 - So I thought that maybe ``softbreak`` was not working because there is no function for it. But that is actually not the case. 
 - The ``softbreak`` was not working because of this conditional statement [here](https://github.com/accordproject/web-components/blob/b6ccb71ca4e103d5c699ad4395653d55597f3919/packages/ui-markdown-editor/src/index.js#L93). This basically means that if ``Enter`` is being pressed from a non-heading block then we totally skip out hotkey actions. That is also the reason why pressing `Ctrl` + `Enter` did not inset a page break. **_If you remove that statement then `softbreak` and page break works like normal._**


 - And this should TOTALLY prevent us from getting a `linebreak` in a paragraph. And the only reason pressing `Enter` is still functional is because of [this](https://github.com/accordproject/web-components/blob/b6ccb71ca4e103d5c699ad4395653d55597f3919/packages/ui-markdown-editor/src/plugins/withLists.js#L9) and [this](https://github.com/accordproject/web-components/blob/b6ccb71ca4e103d5c699ad4395653d55597f3919/packages/ui-markdown-editor/src/plugins/withLinks.js#L66) functions where we are overriding ``insertBreak()``. You can put a few ``console.log()`` there and check which functions work and which do not.


 - That is also the reason why inserting a page break (`Ctrl` + `Enter`) and `softbreak`(`Shift` +  `Enter`) works absolutely fine for all the heading blocks because this conditional statement only restricts non-heading blocks from all the `Enter` functions.


## Exchange in types of `break` **Bug**
 - As I mentioned earlier in the second point that the only functions that existed are the ``insertLinebreak`` and ``insertHeadingbreak``.
 - To find out which function is doing what, we need to remove this conditional statement [here](https://github.com/accordproject/web-components/blob/b6ccb71ca4e103d5c699ad4395653d55597f3919/packages/ui-markdown-editor/src/index.js#L93) and simply add a `console.log()` statement after [this](https://github.com/accordproject/web-components/blob/b6ccb71ca4e103d5c699ad4395653d55597f3919/packages/ui-markdown-editor/src/index.js#L101) line like this:

```
    hotkeys.forEach((hotkey) => {
      if (isHotkey(hotkey, event)) {
        event.preventDefault();
        const { code, type } = HOTKEYS[hotkey];
        console.log(code) <===
        hotkeyActions[type](code);
      }
    })
```
By doing this, we get:

![VoIURQSy9U](https://user-images.githubusercontent.com/59534570/110131027-bad35580-7def-11eb-9345-0e590c6553a3.gif)


### Here:
Pressing `Enter` results in a => `headingbreak`
Pressing `Shift` + `Enter` results in a => `linebreak`

This is the case because this is how it is mentioned in the ``hotkeys`` file as you can see [here](https://github.com/accordproject/web-components/blob/b6ccb71ca4e103d5c699ad4395653d55597f3919/packages/ui-markdown-editor/src/utilities/hotkeys.js#L52).
 - And now we know that pressing `Shift` + `Enter` is creating a `softbreak` as it should but it is named as a `linebreak` and
- Pressing `Enter` is always creating a false `headingbreak` no matter the type of block. It is false `headingbreak` and does not do anything because of the problem I mentioned above that is pressing `Enter` is useless in a non-heading block because of this conditional statement [here](https://github.com/accordproject/web-components/blob/b6ccb71ca4e103d5c699ad4395653d55597f3919/packages/ui-markdown-editor/src/index.js#L93)

---

What is happening till now:
Every time we press Enter, a heading break is going to get inserted.

How it was implemented was:
1. We created a boolean which tells us if the current block is a heading.
2. We created a restriction on the `enter` keyword when being pressed from a non-heading block. This was causing #263 
3. If enter is called from a `headingblock` then we will go to our custom hotkeyActions and create a heading break
4. But if the `enter` is called from a non - heading block then we will skip our custom hotkeyActions and a default enter linebreak will occur



### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->

1. Converted `headingbreak` to linebreak
2. This converts every single enter press to a simple linebreak and if enter is pressed from a heading block, only then we will make it a `headingbreak`
3. This removes the restriction on the enter key in the paragraph so the page break works.


### Related Issues
- Issue  #263 #267 #269 
- Pull Request #220 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [x] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
