### PR TITLE
feat(ui-concerto): Upgrade to Concerto v1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,39 @@
 				"xregexp": "4.2.4"
 			},
 			"dependencies": {
+				"@accordproject/concerto-core": {
+					"version": "0.82.11",
+					"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.11.tgz",
+					"integrity": "sha512-65gZqlC3NqfGsZ68H9a97U96EDdUA4bW5achtqkv/W2YvL2LU1is+FUkoQFNFltpZJp9KfitUqFC0SQ84sAHAA==",
+					"requires": {
+						"axios": "0.19.0",
+						"debug": "4.1.1",
+						"fast-safe-stringify": "2.0.7",
+						"jsome": "2.5.0",
+						"lorem-ipsum": "1.0.6",
+						"moment-mini": "2.22.1",
+						"slash": "3.0.0",
+						"triple-beam": "1.3.0",
+						"urijs": "1.19.1",
+						"uuid": "3.3.2",
+						"winston": "3.2.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						}
+					}
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				},
 				"uuid": {
 					"version": "3.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -40,23 +73,35 @@
 			}
 		},
 		"@accordproject/concerto-core": {
-			"version": "0.82.11",
-			"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.11.tgz",
-			"integrity": "sha512-65gZqlC3NqfGsZ68H9a97U96EDdUA4bW5achtqkv/W2YvL2LU1is+FUkoQFNFltpZJp9KfitUqFC0SQ84sAHAA==",
+			"version": "1.0.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-1.0.0-alpha.2.tgz",
+			"integrity": "sha512-eJCQmsuzuRcrfzQbHDxXqs6RLPynhWnIgCSjS5bSZ02kba0vEuKktfF5fdezyBG0dM+K5b4Z/82zxv8t4mtIDQ==",
 			"requires": {
-				"axios": "0.19.0",
+				"axios": "0.21.1",
+				"colors": "1.4.0",
+				"dayjs": "1.10.2",
 				"debug": "4.1.1",
-				"fast-safe-stringify": "2.0.7",
 				"jsome": "2.5.0",
 				"lorem-ipsum": "1.0.6",
-				"moment-mini": "2.22.1",
+				"randexp": "0.5.3",
 				"slash": "3.0.0",
-				"triple-beam": "1.3.0",
 				"urijs": "1.19.1",
-				"uuid": "3.3.2",
-				"winston": "3.2.1"
+				"uuid": "3.3.2"
 			},
 			"dependencies": {
+				"axios": {
+					"version": "0.21.1",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+					"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+					"requires": {
+						"follow-redirects": "^1.10.0"
+					}
+				},
+				"colors": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+					"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -65,10 +110,15 @@
 						"ms": "^2.1.1"
 					}
 				},
+				"follow-redirects": {
+					"version": "1.13.3",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+					"integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+				},
 				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 				},
 				"uuid": {
 					"version": "3.3.2",
@@ -94,10 +144,53 @@
 				"winston": "3.2.1"
 			},
 			"dependencies": {
+				"@accordproject/concerto-core": {
+					"version": "0.82.11",
+					"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.11.tgz",
+					"integrity": "sha512-65gZqlC3NqfGsZ68H9a97U96EDdUA4bW5achtqkv/W2YvL2LU1is+FUkoQFNFltpZJp9KfitUqFC0SQ84sAHAA==",
+					"requires": {
+						"axios": "0.19.0",
+						"debug": "4.1.1",
+						"fast-safe-stringify": "2.0.7",
+						"jsome": "2.5.0",
+						"lorem-ipsum": "1.0.6",
+						"moment-mini": "2.22.1",
+						"slash": "3.0.0",
+						"triple-beam": "1.3.0",
+						"urijs": "1.19.1",
+						"uuid": "3.3.2",
+						"winston": "3.2.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"fast-safe-stringify": {
+							"version": "2.0.7",
+							"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+							"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+						}
+					}
+				},
 				"fast-safe-stringify": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.5.tgz",
 					"integrity": "sha512-QHbbCj2PmRSMNL9P7EuNBCeNXO06/E3t3XyQgb32AZul8wLmRa1Wbt2cm7GeUsX9OZGyXTQxMYcPOEBqARyhNw=="
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 				}
 			}
 		},
@@ -121,6 +214,44 @@
 				"@accordproject/markdown-it-cicero": "0.12.12",
 				"markdown-it": "^11.0.0",
 				"winston": "3.2.1"
+			},
+			"dependencies": {
+				"@accordproject/concerto-core": {
+					"version": "0.82.11",
+					"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.11.tgz",
+					"integrity": "sha512-65gZqlC3NqfGsZ68H9a97U96EDdUA4bW5achtqkv/W2YvL2LU1is+FUkoQFNFltpZJp9KfitUqFC0SQ84sAHAA==",
+					"requires": {
+						"axios": "0.19.0",
+						"debug": "4.1.1",
+						"fast-safe-stringify": "2.0.7",
+						"jsome": "2.5.0",
+						"lorem-ipsum": "1.0.6",
+						"moment-mini": "2.22.1",
+						"slash": "3.0.0",
+						"triple-beam": "1.3.0",
+						"urijs": "1.19.1",
+						"uuid": "3.3.2",
+						"winston": "3.2.1"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+				}
 			}
 		},
 		"@accordproject/markdown-common": {
@@ -132,6 +263,44 @@
 				"markdown-it": "^11.0.0",
 				"winston": "3.2.1",
 				"xmldom": "^0.1.27"
+			},
+			"dependencies": {
+				"@accordproject/concerto-core": {
+					"version": "0.82.11",
+					"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.11.tgz",
+					"integrity": "sha512-65gZqlC3NqfGsZ68H9a97U96EDdUA4bW5achtqkv/W2YvL2LU1is+FUkoQFNFltpZJp9KfitUqFC0SQ84sAHAA==",
+					"requires": {
+						"axios": "0.19.0",
+						"debug": "4.1.1",
+						"fast-safe-stringify": "2.0.7",
+						"jsome": "2.5.0",
+						"lorem-ipsum": "1.0.6",
+						"moment-mini": "2.22.1",
+						"slash": "3.0.0",
+						"triple-beam": "1.3.0",
+						"urijs": "1.19.1",
+						"uuid": "3.3.2",
+						"winston": "3.2.1"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+				}
 			}
 		},
 		"@accordproject/markdown-docx": {
@@ -206,6 +375,37 @@
 				"uuid": "3.3.2"
 			},
 			"dependencies": {
+				"@accordproject/concerto-core": {
+					"version": "0.82.11",
+					"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.11.tgz",
+					"integrity": "sha512-65gZqlC3NqfGsZ68H9a97U96EDdUA4bW5achtqkv/W2YvL2LU1is+FUkoQFNFltpZJp9KfitUqFC0SQ84sAHAA==",
+					"requires": {
+						"axios": "0.19.0",
+						"debug": "4.1.1",
+						"fast-safe-stringify": "2.0.7",
+						"jsome": "2.5.0",
+						"lorem-ipsum": "1.0.6",
+						"moment-mini": "2.22.1",
+						"slash": "3.0.0",
+						"triple-beam": "1.3.0",
+						"urijs": "1.19.1",
+						"uuid": "3.3.2",
+						"winston": "3.2.1"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				},
 				"uuid": {
 					"version": "3.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -228,6 +428,44 @@
 				"@accordproject/markdown-template": "0.12.12",
 				"dijkstrajs": "^1.0.1",
 				"moment-mini": "2.22.1"
+			},
+			"dependencies": {
+				"@accordproject/concerto-core": {
+					"version": "0.82.11",
+					"resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-0.82.11.tgz",
+					"integrity": "sha512-65gZqlC3NqfGsZ68H9a97U96EDdUA4bW5achtqkv/W2YvL2LU1is+FUkoQFNFltpZJp9KfitUqFC0SQ84sAHAA==",
+					"requires": {
+						"axios": "0.19.0",
+						"debug": "4.1.1",
+						"fast-safe-stringify": "2.0.7",
+						"jsome": "2.5.0",
+						"lorem-ipsum": "1.0.6",
+						"moment-mini": "2.22.1",
+						"slash": "3.0.0",
+						"triple-beam": "1.3.0",
+						"urijs": "1.19.1",
+						"uuid": "3.3.2",
+						"winston": "3.2.1"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+				}
 			}
 		},
 		"@ardatan/aggregate-error": {
@@ -15320,6 +15558,11 @@
 			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
 			"dev": true
 		},
+		"dayjs": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.2.tgz",
+			"integrity": "sha512-h/YtykNNTR8Qgtd1Fxl5J1/SFP1b7SOk/M1P+Re+bCdFMV0IMkuKNgHPN7rlvvuhfw24w0LX78iYKt4YmePJNQ=="
+		},
 		"debug": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
@@ -16752,6 +16995,11 @@
 			"requires": {
 				"dotenv-defaults": "^1.0.2"
 			}
+		},
+		"drange": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+			"integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
 		},
 		"duck": {
 			"version": "0.1.11",
@@ -36472,6 +36720,22 @@
 			"version": "0.21.0",
 			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
 			"integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU="
+		},
+		"randexp": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+			"integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+			"requires": {
+				"drange": "^1.0.2",
+				"ret": "^0.2.0"
+			},
+			"dependencies": {
+				"ret": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+					"integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
+				}
+			}
 		},
 		"randombytes": {
 			"version": "2.1.0",

--- a/packages/storybook/src/stories/3-ConcertoForm.stories.js
+++ b/packages/storybook/src/stories/3-ConcertoForm.stories.js
@@ -8,6 +8,9 @@ export default {
   component: ConcertoForm,
   parameters: {
     componentSubtitle: 'Create dynamic forms from Concerto models',
+    knobs: {
+      escapeHTML: false,
+    },
   }
 };
 

--- a/packages/ui-concerto/package.json
+++ b/packages/ui-concerto/package.json
@@ -3,7 +3,7 @@
   "version": "0.96.1",
   "private": false,
   "dependencies": {
-    "@accordproject/concerto-core": "^0.82.11",
+    "@accordproject/concerto-core": "^1.0.0-alpha.2",
     "@babel/runtime": "^7.10.3",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
@@ -16,8 +16,9 @@
     "semantic-ui-react": "^0.88.2"
   },
   "scripts": {
-    "test": "SKIP_PREFLIGHT_CHECK=true react-scripts test --env=jest-environment-jsdom-sixteen",
+    "test": "SKIP_PREFLIGHT_CHECK=true react-scripts test --coverage --env=jest-environment-jsdom-sixteen",
     "build": "npx rollup -c --sourcemap",
+    "build:watch": "npx rollup -c --sourcemap -w",
     "build:prod": "npx rollup -c",
     "fix:js": "npx eslint --fix ./src/",
     "lint:js": "npx eslint ./src/",

--- a/packages/ui-concerto/src/__snapshots__/formgenerator.test.js.snap
+++ b/packages/ui-concerto/src/__snapshots__/formgenerator.test.js.snap
@@ -1,0 +1,192 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formgenerator Tests #instantiate generates a form from text 1`] = `
+<div>
+  <div>
+    <div
+      class="required field"
+    >
+      <label
+        for="name"
+      >
+        Name
+      </label>
+      <div
+        class="ui input"
+      >
+        <input
+          id="name"
+          type="text"
+          value="resource1"
+        />
+      </div>
+    </div>
+    <div
+      class="required field"
+    >
+      <label>
+        Address
+      </label>
+      <div
+        class="required field"
+      >
+        <label
+          for="address.$identifier"
+        >
+          $identifier
+        </label>
+        <div
+          class="ui input"
+        >
+          <input
+            id="address.$identifier"
+            type="text"
+            value="a9c0177b-f08f-417e-a956-7a7c9e9701e5"
+          />
+        </div>
+      </div>
+      <div
+        class="required field"
+      >
+        <label
+          for="address.street"
+        >
+          Street
+        </label>
+        <div
+          class="ui input"
+        >
+          <input
+            id="address.street"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="required field"
+      >
+        <label
+          for="address.city"
+        >
+          City
+        </label>
+        <div
+          class="ui input"
+        >
+          <input
+            id="address.city"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="required field"
+      >
+        <label>
+          Country
+        </label>
+        <div
+          aria-expanded="false"
+          class="ui fluid selection dropdown"
+          role="listbox"
+          tabindex="0"
+        >
+          <div
+            aria-atomic="true"
+            aria-live="polite"
+            class="text"
+            role="alert"
+          >
+            USA
+          </div>
+          <i
+            aria-hidden="true"
+            class="dropdown icon"
+          />
+          <div
+            class="menu transition"
+          >
+            <div
+              aria-checked="true"
+              aria-selected="true"
+              class="active selected item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                USA
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                UK
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                France
+              </span>
+            </div>
+            <div
+              aria-checked="false"
+              aria-selected="false"
+              class="item"
+              role="option"
+              style="pointer-events: all;"
+            >
+              <span
+                class="text"
+              >
+                Sweden
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="field"
+    >
+      <label>
+        Children
+      </label>
+      <div
+        class="arrayElement grid"
+      >
+        <div />
+        <div>
+          <button
+            aria-label="Add an element to Children"
+            class="ui basic circular icon button arrayButton"
+          >
+            <i
+              aria-hidden="true"
+              class="plus circle icon"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/ui-concerto/src/components/__snapshots__/concertoFormWrapper.test.js.snap
+++ b/packages/ui-concerto/src/components/__snapshots__/concertoFormWrapper.test.js.snap
@@ -9,13 +9,16 @@ exports[`render form creates a React form for model booleans.cto 1`] = `
     <div
       class="required field"
     >
-      <label>
+      <label
+        for="name"
+      >
         Name
       </label>
       <div
         class="ui input"
       >
         <input
+          id="name"
           type="text"
           value="Sandy"
         />
@@ -24,7 +27,9 @@ exports[`render form creates a React form for model booleans.cto 1`] = `
     <div
       class="required field"
     >
-      <label>
+      <label
+        for="employed"
+      >
         Employed
       </label>
       <div
@@ -32,18 +37,23 @@ exports[`render form creates a React form for model booleans.cto 1`] = `
       >
         <input
           class="hidden"
+          id="employed"
           readonly=""
           tabindex="0"
           type="checkbox"
           value=""
         />
-        <label />
+        <label
+          for="employed"
+        />
       </div>
     </div>
     <div
       class="required field"
     >
-      <label>
+      <label
+        for="retired"
+      >
         Retired
       </label>
       <div
@@ -52,12 +62,15 @@ exports[`render form creates a React form for model booleans.cto 1`] = `
         <input
           checked=""
           class="hidden"
+          id="retired"
           readonly=""
           tabindex="0"
           type="checkbox"
           value=""
         />
-        <label />
+        <label
+          for="retired"
+        />
       </div>
     </div>
   </form>
@@ -73,13 +86,16 @@ exports[`render form creates a React form for model datetime.cto 1`] = `
     <div
       class="required field"
     >
-      <label>
+      <label
+        for="name"
+      >
         Name
       </label>
       <div
         class="ui input"
       >
         <input
+          id="name"
           type="text"
           value="Sandy"
         />
@@ -88,7 +104,9 @@ exports[`render form creates a React form for model datetime.cto 1`] = `
     <div
       class="required field"
     >
-      <label>
+      <label
+        for="birthday"
+      >
         Birthday
       </label>
       <div
@@ -102,6 +120,7 @@ exports[`render form creates a React form for model datetime.cto 1`] = `
             class="calendar icon"
           />
           <input
+            id="birthday"
             tabindex="0"
             type="text"
             value="2010-10-01"
@@ -112,13 +131,16 @@ exports[`render form creates a React form for model datetime.cto 1`] = `
     <div
       class="required field"
     >
-      <label>
+      <label
+        for="age"
+      >
         Age
       </label>
       <div
         class="ui input"
       >
         <input
+          id="age"
           type="number"
           value="10"
         />
@@ -137,13 +159,16 @@ exports[`render form creates a React form for model relationship.cto 1`] = `
     <div
       class="required field"
     >
-      <label>
+      <label
+        for="name"
+      >
         Name
       </label>
       <div
         class="ui input"
       >
         <input
+          id="name"
           type="text"
           value="resource1"
         />
@@ -158,13 +183,34 @@ exports[`render form creates a React form for model relationship.cto 1`] = `
       <div
         class="required field"
       >
-        <label>
+        <label
+          for="address.$identifier"
+        >
+          $identifier
+        </label>
+        <div
+          class="ui input"
+        >
+          <input
+            id="address.$identifier"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="required field"
+      >
+        <label
+          for="address.street"
+        >
           Street
         </label>
         <div
           class="ui input"
         >
           <input
+            id="address.street"
             type="text"
             value="Quis irure."
           />
@@ -173,13 +219,16 @@ exports[`render form creates a React form for model relationship.cto 1`] = `
       <div
         class="required field"
       >
-        <label>
+        <label
+          for="address.city"
+        >
           City
         </label>
         <div
           class="ui input"
         >
           <input
+            id="address.city"
             type="text"
             value="Ipsum elit."
           />
@@ -321,6 +370,2541 @@ exports[`render form creates a React form for model relationship.cto 1`] = `
             />
           </button>
         </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`render form creates a React form for model specialTypes.cto 1`] = `
+<div>
+  <form
+    class="ui form"
+    style="min-height: 100px;"
+  >
+    <div
+      class="required field"
+    >
+      <label
+        for="name"
+      >
+        Name
+      </label>
+      <div
+        class="ui input"
+      >
+        <input
+          id="name"
+          type="text"
+          value="Matt"
+        />
+      </div>
+    </div>
+    <div
+      class="required field"
+    >
+      <label>
+        Value
+      </label>
+      <div
+        class="monetaryAmount"
+      >
+        <div>
+          <div
+            class="required field"
+          >
+            <div
+              class="ui input"
+            >
+              <input
+                id="value.doubleValue"
+                type="number"
+                value="1"
+              />
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            class="required field"
+          >
+            <div
+              aria-expanded="false"
+              class="ui fluid selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="text"
+                role="alert"
+              >
+                GBP
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    AED
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    AFN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ALL
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    AMD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ANG
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    AOA
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ARS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    AUD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    AWG
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    AZN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BAM
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BBD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BDT
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BGN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BHD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BIF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BMD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BND
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BOB
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BOV
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BRL
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BSD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BTN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BWP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BYN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    BZD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CAD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CDF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CHE
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CHF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CHW
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CLF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CLP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CNY
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    COP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    COU
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CRC
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CUC
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CUP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CVE
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    CZK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    DJF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    DKK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    DOP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    DZD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    EGP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ERN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ETB
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    EUR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    FJD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    FKP
+                  </span>
+                </div>
+                <div
+                  aria-checked="true"
+                  aria-selected="true"
+                  class="active selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GBP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GEL
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GHS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GIP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GMD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GNF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GTQ
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    GYD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    HKD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    HNL
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    HRK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    HTG
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    HUF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    IDR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ILS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    INR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    IQD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    IRR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ISK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    JMD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    JOD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    JPY
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KES
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KGS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KHR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KMF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KPW
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KRW
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KWD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KYD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    KZT
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LAK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LBP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LKR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LRD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LSL
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    LYD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MAD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MDL
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MGA
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MKD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MMK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MNT
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MOP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MRU
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MUR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MVR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MWK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MXN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MXV
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MYR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    MZN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    NAD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    NGN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    NIO
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    NOK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    NPR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    NZD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    OMR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    PAB
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    PEN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    PGK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    PHP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    PKR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    PLN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    PYG
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    QAR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    RON
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    RSD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    RUB
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    RWF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SAR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SBD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SCR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SDG
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SEK
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SGD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SHP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SLL
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SOS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SRD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SSP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    STN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SVC
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SYP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    SZL
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    THB
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    TJS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    TMT
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    TND
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    TOP
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    TRY
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    TTD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    TWD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    TZS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    UAH
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    UGX
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    USD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    USN
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    UYI
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    UYU
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    UZS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    VEF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    VND
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    VUV
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    WST
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XAF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XAG
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XAU
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XBA
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XBB
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XBC
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XBD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XCD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XDR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XOF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XPD
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XPF
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XPT
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XSU
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XTS
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XUA
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    XXX
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    YER
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ZAR
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ZMW
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    ZWL
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="required field"
+    >
+      <label>
+        Duration
+      </label>
+      <div
+        class="duration"
+      >
+        <div>
+          <div
+            class="required field"
+          >
+            <div
+              class="ui input"
+            >
+              <input
+                id="duration.amount"
+                type="number"
+                value="1"
+              />
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            class="required field"
+          >
+            <div
+              aria-expanded="false"
+              class="ui fluid selection dropdown"
+              role="listbox"
+              tabindex="0"
+            >
+              <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="text"
+                role="alert"
+              >
+                seconds
+              </div>
+              <i
+                aria-hidden="true"
+                class="dropdown icon"
+              />
+              <div
+                class="menu transition"
+              >
+                <div
+                  aria-checked="true"
+                  aria-selected="true"
+                  class="active selected item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    seconds
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    minutes
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    hours
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    days
+                  </span>
+                </div>
+                <div
+                  aria-checked="false"
+                  aria-selected="false"
+                  class="item"
+                  role="option"
+                  style="pointer-events: all;"
+                >
+                  <span
+                    class="text"
+                  >
+                    weeks
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="required field"
+    >
+      <label
+        for="payee"
+      >
+        Payee
+      </label>
+      <div
+        class="ui input"
+      >
+        <input
+          id="payee"
+          type="text"
+          value="matt"
+        />
       </div>
     </div>
   </form>

--- a/packages/ui-concerto/src/components/concertoForm.js
+++ b/packages/ui-concerto/src/components/concertoForm.js
@@ -22,7 +22,6 @@ import { ModelManager } from '@accordproject/concerto-core';
 
 import ReactFormVisitor from '../reactformvisitor';
 import FormGenerator from '../formgenerator';
-import { decodeHTMLEntities } from '../utilities';
 import './concertoForm.css';
 
 /**
@@ -55,9 +54,10 @@ const ConcertoForm = (props) => {
 
   const addElement = useCallback((e, key, elementValue) => {
     const array = get(value, key) || [];
+    const path = typeof key === 'string' ? [key] : key;
     const valueClone = set(
       { ...value },
-      [...key, array.length],
+      [...path, array.length],
       elementValue
     );
     setValue(valueClone);
@@ -108,8 +108,7 @@ const ConcertoForm = (props) => {
       true
     );
     models.forEach((model, idx) => {
-      const decodedModel = decodeHTMLEntities(model);
-      modelManager.addModelFile(decodedModel, `model-${idx}`, true);
+      modelManager.addModelFile(model, `model-${idx}`, true);
     });
     if (options.updateExternalModels) {
       modelManager.updateExternalModels().then(() => {

--- a/packages/ui-concerto/src/components/fields.js
+++ b/packages/ui-concerto/src/components/fields.js
@@ -18,8 +18,8 @@ import { Checkbox, Input, Form, Button, Select, Popup, Label, Icon } from 'seman
 import { DateTimeInput } from 'semantic-ui-calendar-react';
 import { parseValue, normalizeLabel } from '../utilities';
 
-export const ConcertoLabel = ({ skip, name }) => !skip
-  ? <label>{normalizeLabel(name)}</label> : null;
+export const ConcertoLabel = ({ skip, name, htmlFor }) => !skip
+  ? <label htmlFor={htmlFor}>{normalizeLabel(name)}</label> : null;
 
 export const ConcertoCheckbox = ({
   id,
@@ -31,9 +31,10 @@ export const ConcertoCheckbox = ({
   skipLabel,
 }) => (
   <Form.Field required={required}>
-    <ConcertoLabel skip={skipLabel} name={field.getName()} />
+    <ConcertoLabel skip={skipLabel} name={field.getName()} htmlFor={id} />
     <Checkbox
       toggle
+      id={id}
       readOnly={readOnly}
       checked={value}
       onChange={(e, data) => onFieldValueChange(data, id)}
@@ -53,8 +54,9 @@ export const ConcertoInput = ({
   type,
 }) => (
   <Form.Field key={`field-${id}`} required={required}>
-    <ConcertoLabel key={`label-${id}`} skip={skipLabel} name={field.getName()} />
+    <ConcertoLabel key={`label-${id}`} skip={skipLabel} name={field.getName()} htmlFor={id} />
     <Input
+      id={id}
       type={type}
       readOnly={readOnly}
       value={value}
@@ -143,13 +145,14 @@ export const ConcertoDateTime = ({
   skipLabel,
 }) => (
   <Form.Field required={required}>
-    <ConcertoLabel skip={skipLabel} name={field.getName()} />
+    <ConcertoLabel skip={skipLabel} name={field.getName()} htmlFor={id} />
     <DateTimeInput
       readOnly={readOnly}
       value={value}
       onChange={(e, data) => onFieldValueChange(data, id)}
       dateTimeFormat={'YYYY-MM-DDTHH:mm:ss.sssZ'}
       key={id}
+      id={id}
       animation='none'
     />
   </Form.Field>

--- a/packages/ui-concerto/src/formgenerator.js
+++ b/packages/ui-concerto/src/formgenerator.js
@@ -178,15 +178,9 @@ class FormGenerator {
     let { visitor } = params;
     if (!visitor) {
       visitor = new ReactFormVisitor();
-      params.wrapHtmlForm = true;
     }
 
-    const form = classDeclaration.accept(visitor, params);
-    if (params.wrapHtmlForm) {
-      return visitor.wrapHtmlForm(form, params);
-    }
-
-    return form;
+    return classDeclaration.accept(visitor, params);
   }
 }
 

--- a/packages/ui-concerto/src/reactformvisitor.js
+++ b/packages/ui-concerto/src/reactformvisitor.js
@@ -123,7 +123,7 @@ class ReactFormVisitor {
       }
     }
 
-    if (classDeclaration.isSystemType() || classDeclaration.isAbstract()) {
+    if (classDeclaration.isAbstract()) {
       return null;
     }
 

--- a/packages/ui-concerto/src/utilities.js
+++ b/packages/ui-concerto/src/utilities.js
@@ -110,8 +110,7 @@ export const findConcreteSubclass = declaration => {
 
   const concreteSubclasses = declaration
     .getAssignableClassDeclarations()
-    .filter(subclass => !subclass.isAbstract())
-    .filter(subclass => !subclass.isSystemType());
+    .filter(subclass => !subclass.isAbstract());
 
   if (concreteSubclasses.length === 0) {
     throw new Error('No concrete subclasses found');
@@ -176,24 +175,3 @@ export const getDefaultValue = (field, parameters) => {
     });
   return parameters.modelManager.getSerializer().toJSON(resource);
 };
-
-const entities = {
-  amp: '&',
-  apos: '\'',
-  '#x27': '\'',
-  '#x2F': '/',
-  '#39': '\'',
-  '#47': '/',
-  lt: '<',
-  gt: '>',
-  nbsp: ' ',
-  quot: '"'
-};
-
-/**
- * Helper function to decode html in models (needed bc of Storybook)
- * @param {String} text - model string
- * @return {String} - decoded model string
- * @private
- */
-export const decodeHTMLEntities = (text) => text.replace(/&([^;]+);/gm, (match, entity) => entities[entity] || match);

--- a/packages/ui-concerto/test/data/relationship.cto
+++ b/packages/ui-concerto/test/data/relationship.cto
@@ -1,22 +1,22 @@
 namespace test 
 
-  enum Country {
-    o USA
-    o UK
-    o France
-    o Sweden
-  }
+enum Country {
+  o USA
+  o UK
+  o France
+  o Sweden
+}
 
-  participant Person identified by name {
-    o String name
-    o Address address
-    --> Person[] children optional
-  }
+participant Person identified by name {
+  o String name
+  o Address address
+  --> Person[] children optional
+}
 
-  concept Address {
-    o String street
-    o String city
-    @FormEditor( "hide", true)
-    o String zipCode
-    o Country country
-  }
+concept Address identified {
+  o String street
+  o String city
+  @FormEditor( "hide", true)
+  o String zipCode
+  o Country country
+}

--- a/packages/ui-concerto/test/data/specialTypes.cto
+++ b/packages/ui-concerto/test/data/specialTypes.cto
@@ -1,0 +1,13 @@
+namespace test 
+
+import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money@0.2.0.cto
+import org.accordproject.time.Duration from https://models.accordproject.org/time@0.2.0.cto
+import org.accordproject.cicero.contract.AccordParty from https://models.accordproject.org/cicero/contract.cto
+
+concept Person {
+  o String name
+  o MonetaryAmount value
+  o Duration duration
+  --> AccordParty payee
+  o String hiddenInConfig
+}

--- a/packages/ui-concerto/test/data/specialTypes.json
+++ b/packages/ui-concerto/test/data/specialTypes.json
@@ -1,0 +1,15 @@
+{
+  "$class": "test.Person",
+  "name": "Matt",
+  "value": {
+    "$class": "org.accordproject.money.MonetaryAmount",
+    "doubleValue": 1.0,
+    "currencyCode": "GBP"
+  },
+  "duration": {
+    "$class": "org.accordproject.time.Duration",
+    "amount": 1,
+    "unit": "seconds"
+  },
+  "payee": "matt"
+}


### PR DESCRIPTION
Upgrades `ui-concerto` to use `@accordproject/concerto-core@1.0.0-alpha.2`, and improves testing coverage.

### Changes
- Follows the changes in the Concerto migration guide, https://docs.accordproject.org/docs/next/ref-migrate-concerto-0.82-1.0.html
- Adds unit tests for `identified` keyword
- Adds unit test for array buttons (add / remove element). And fixed a related bug in the value provided to `onValueChange`.
- Adds unit tests for the built-in "special types" such as `MonetaryAmount` which has a special rendering path 
- Storybook now uses the built-in HTML entity escaping rather than our custom escaping
- Improves A11Y by adding `htmlFor` labels to input fields. This also makes testing easier.

### Coverage
File                  |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------------------|----------|----------|----------|----------|-------------------|
All files             |    72.45 |    62.32 |    82.35 |    72.03 |                   |
 src                  |    68.66 |     61.4 |    77.78 |    68.18 |                   |
  formgenerator.js    |    60.47 |       50 |       75 |    60.47 |... 37,157,161,167 |
  reactformvisitor.js |       80 |    77.19 |    83.33 |    79.61 |... 78,285,286,347 |
  utilities.js        |    52.83 |    42.86 |       70 |    51.92 |... 62,168,170,176 |
 src/components       |    84.38 |    66.67 |    93.33 |    84.13 |                   |
  concertoForm.js     |    84.38 |    66.67 |    93.33 |    84.13 |... 62,163,173,186 |

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [] Contrast at least WCAG Level A
    - [x] Appropriate labels, alt text, and instructions
