### PR TITLE
fix(ui-markdown-editor): typo in readme - #274

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run storybook
 This repository is a monorepo, built using [lerna](https://lerna.js.org). Each package is published as an independent npm module.
 
 - [Markdown Editor](packages/ui-markdown-editor): A WYSIWYG editor based on [Slate](https://www.slatejs.org) for markdown that conforms to the [CommonMark](https://spec.commonmark.org) specification.
-- [Contract Editor](packages/ui-contract-edtior): An editor based on our [Markdown Editor](packages/ui-markdown-editor) for handling smart legal contracts.
+- [Contract Editor](packages/ui-contract-editor): An editor based on our [Markdown Editor](packages/ui-markdown-editor) for handling smart legal contracts.
 - [Concerto UI](packages/ui-concerto): React components for models written in the [Concerto Modeling Language](https://github.com/accordproject/concerto).
 - [Web Components](packages/ui-components): Tools for implementing React components in your contract editing studio.
 - [Storybook](packages/storybook): A [React Storybook](https://storybook.js.org), and contains all the stories for all the sub-packages.


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
This typo was causing the ``404`` error as it was not linking to the contract editor repository. It works now.

### Changes
```diff
- [Contract Editor](packages/ui-contract-edtior): An editor based on our [Markdown Editor](packages/ui-markdown-editor) for handling smart legal contracts.
+ [Contract Editor](packages/ui-contract-editor): An editor based on our [Markdown Editor](packages/ui-markdown-editor) for handling smart legal contracts.

```



### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![uN0HQx2bPM](https://user-images.githubusercontent.com/59534570/109768758-5366ab80-7c1f-11eb-9180-2be82842103b.gif)


### Related Issues
- Issue #274 


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
