### PR TITLE
style(ui-contract-editor): Drag-Drop Handle Resize - I137

### DIFF
--- a/packages/ui-contract-editor/src/components/Clause/index.js
+++ b/packages/ui-contract-editor/src/components/Clause/index.js
@@ -161,6 +161,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
               >
               <S.DragIcon
                 {...upIconProps}
+                position={-3}
                 onClick={handleClick}
               >
                 {upIcon.icon()}
@@ -170,6 +171,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
               </ S.DragIcon>
               <S.DragIcon
                 {...downIconProps}
+                position={-10}
                 onClick={(e) => handleClick(e, true)}
               >
                 {downIcon.icon()}

--- a/packages/ui-contract-editor/src/components/Clause/index.js
+++ b/packages/ui-contract-editor/src/components/Clause/index.js
@@ -76,8 +76,8 @@ const ClauseComponent = React.forwardRef((props, ref) => {
   const dragIconProps = {
     'aria-label': dragIcon.type,
     width: '12px',
-    height: '22px',
-    viewBox: '0 0 12 22',
+    height: '15px',
+    viewBox: '0 0 12 15',
   };
 
   const upIconProps = {
@@ -158,6 +158,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
           && header.length !== 0 ? <>
               <S.DragWrapper
                 {...iconWrapperProps}
+                style={{ marginBottom: '0px', position: 'relative', top: '-5px', maxHeight: '50px' }}
               >
               <S.DragIcon
                 {...upIconProps}
@@ -165,7 +166,7 @@ const ClauseComponent = React.forwardRef((props, ref) => {
               >
                 {upIcon.icon()}
               </ S.DragIcon>
-              <S.DragIcon {...dragIconProps} style={{ margin: '6px 0 0 2px' }}>
+              <S.DragIcon {...dragIconProps} >
                 {dragIcon.icon()}
               </ S.DragIcon>
               <S.DragIcon

--- a/packages/ui-contract-editor/src/components/Clause/index.js
+++ b/packages/ui-contract-editor/src/components/Clause/index.js
@@ -158,7 +158,6 @@ const ClauseComponent = React.forwardRef((props, ref) => {
           && header.length !== 0 ? <>
               <S.DragWrapper
                 {...iconWrapperProps}
-                style={{ marginBottom: '0px', position: 'relative', top: '-5px', maxHeight: '50px' }}
               >
               <S.DragIcon
                 {...upIconProps}

--- a/packages/ui-contract-editor/src/components/styles.js
+++ b/packages/ui-contract-editor/src/components/styles.js
@@ -147,6 +147,10 @@ export const DragWrapper = styled(IconWrapper)`
   grid-area: fifteen;
   background: linear-gradient(to right, #FFF 0%, #F4F6FC 100%);
   margin-right: 9px;
+  margin-bottom: 0px;
+  position: relative;
+  top: -5px;
+  max-height: 50px;
   padding: 4px 0 0 0;
   cursor: text;
 `;

--- a/packages/ui-contract-editor/src/components/styles.js
+++ b/packages/ui-contract-editor/src/components/styles.js
@@ -114,6 +114,8 @@ export const ClauseIcon = styled.svg`
 
 export const DragIcon = styled(ClauseIcon)`
   fill: #949CA2;
+  position: relative;
+  top: ${props => (props.position ?? -6)}px;
   &:hover {
     fill: #414F58;
   }

--- a/packages/ui-contract-editor/src/icons/drag.js
+++ b/packages/ui-contract-editor/src/icons/drag.js
@@ -4,7 +4,7 @@ export const type = () => 'drag';
 
 export const icon = () => (
     <g id="Side-nav-+-new-editor" stroke="none" strokeWidth="1" fillRule="evenodd">
-        <g id="Drag-and-drop" transform="translate(-302.000000, -457.000000)">
+        <g id="Drag-and-drop" transform="translate(-300.250000, -457.000000)">
             <g id="handle" transform="translate(297.000000, 455.000000)">
                 <rect id="Rectangle" x="0" y="0" width="18" height="22" fill="none"></rect>
                 <g id="Group-5" transform="translate(5.000000, 2.000000)" fillRule="nonzero">


### PR DESCRIPTION
Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #137 <CORRESPONDING ISSUE NUMBER>
Styling changes applied to the drag & drop handle so that short clauses don't have large space.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Changes in margin
- <TWO> Some changes in svg and height

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![Screenshot from 2021-03-03 00-37-03](https://user-images.githubusercontent.com/59891164/109797744-dbf54400-7c3f-11eb-9fda-01859d70de9b.png)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
