### PR TITLE
fix(ui-markdown-editor): text deselection - #291

### DIFF
--- a/packages/ui-markdown-editor/src/FormattingToolbar/StyleFormat/index.js
+++ b/packages/ui-markdown-editor/src/FormattingToolbar/StyleFormat/index.js
@@ -15,11 +15,17 @@ import {
 
 const StyleDropdown = ({ canBeFormatted, currentStyle }) => {
   const editor = useEditor();
+  const onMouseDownHandler = (event) => {
+    event.preventDefault();
+    if (!canBeFormatted(editor)) return;
+  }
+
   const currentBlock = currentStyle;
   return (
     <Dropdown
         simple
         openOnFocus
+        onMouseDown={onMouseDownHandler}
         text={currentBlock}
         style={DROPDOWN_STYLE}
       >


### PR DESCRIPTION
Signed-off-by: d-e-v-esh <59534570+d-e-v-esh@users.noreply.github.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #291
<!--- Provide an overall summary of the pull request -->

Beforehand, selecting any kind of text and then clicking on the dropdown menu used to dismiss the selection. Now clicking on the drop-down menu does not affect the selected text.



### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- A new function was added called `onMouseDownHandler` which was routed to the `onMouseDown` prop for the dropdown menu.
- This function includes `event.preventDefault()` which fixes the issue.



### Screenshots or Video
![P1O6ZfAIYS](https://user-images.githubusercontent.com/59534570/110777766-7defde80-8287-11eb-9e26-23516701a3a1.gif)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [x] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [x] Appropriate labels, alt text, and instructions
