### PR TITLE
K kumar 01/i295/hyperlink modal popup

### DIFF
--- a/packages/ui-markdown-editor/src/components/index.js
+++ b/packages/ui-markdown-editor/src/components/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/display-name */
-import React from 'react';
+import React,{useState} from 'react';
 import PropTypes from 'prop-types';
 import ImageElement from '../plugins/withImages';
 import { Heading } from './Node';
@@ -20,6 +20,9 @@ import {
 import generateId from '../utilities/generateId';
 
 const Element = (props) => {
+  const showModal = () => {
+    props.setShowLinkModal(true);
+  }
   const {
     attributes, children, element, customElements, editor
   } = props;
@@ -40,7 +43,7 @@ const Element = (props) => {
       </span>
       {children}
     </span>),
-    [LINK]: () => (<a {...attributes} href={data.href}>{children}</a>),
+    [LINK]: () => (<a onClick={showModal} {...attributes} href={data.href}>{children}</a>),
     [HTML_BLOCK]: () => (<pre className={HTML_BLOCK} {...attributes}>{children}</pre>),
     [CODE_BLOCK]: () => (<pre {...attributes}>{children}</pre>),
     [BLOCK_QUOTE]: () => (<blockquote {...attributes}>{children}</blockquote>),
@@ -70,7 +73,8 @@ Element.propTypes = {
     type: PropTypes.string
   }),
   attributes: PropTypes.any,
-  editor: PropTypes.any
+  editor: PropTypes.any,
+  setShowLinkModal: PropTypes.func
 };
 
 export default Element;

--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -72,7 +72,7 @@ export const MarkdownEditor = (props) => {
       return editor.redo();
     },
     link: () => {
-      // setShowLinkModal(true);
+      setShowLinkModal(true);
     },
     horizontal_rule: (code) => insertThematicBreak(editor, code),
     linebreak: (code) => insertLinebreak(editor, code),

--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -54,7 +54,7 @@ export const MarkdownEditor = (props) => {
 
   const renderLeaf = useCallback(props => <Leaf {...props} />, []);
   const renderElement = useCallback((slateProps) => {
-    const elementProps = { ...slateProps, customElements: props.customElements, editor };
+    const elementProps = { ...slateProps, customElements: props.customElements, editor, setShowLinkModal };
     return (<Element {...elementProps} />);
   }, [props.customElements, editor]);
 
@@ -72,7 +72,7 @@ export const MarkdownEditor = (props) => {
       return editor.redo();
     },
     link: () => {
-      setShowLinkModal(true);
+      // setShowLinkModal(true);
     },
     horizontal_rule: (code) => insertThematicBreak(editor, code),
     linebreak: (code) => insertLinebreak(editor, code),
@@ -143,9 +143,6 @@ export const MarkdownEditor = (props) => {
     if (props.readOnly) return;
     props.onChange(value, editor);
     const { selection } = editor;
-    if (selection && isSelectionLinkBody(editor)) {
-      setShowLinkModal(true);
-    }
     const currentStyleCalculated = BLOCK_STYLE[Node.parent(editor, editor.selection.focus.path).type] || 'Style';
     setCurrentStyle(currentStyleCalculated);
   };


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #295 <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Navigating through the link via arrow keys now doesn't open the popup.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Passed the `setShowLinkModal` as prop in `ElementRenderer`
- <TWO> Add onClick to the render `LINK` and removed the selection to check if it is link.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
https://www.loom.com/share/50e92dde9b3c4b10a6eb2fe39c76b8c1

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
