### PR TITLE
fix(ui-markdown-editor): handle cut image operation - #294

### DIFF
--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -14,9 +14,8 @@ import { BUTTON_ACTIVE } from './utilities/constants';
 import withSchema from './utilities/schema';
 import Element from './components';
 import Leaf from './components/Leaf';
-import { toggleMark, toggleBlock, insertThematicBreak, 
-  insertLinebreak, insertHeadingbreak, isBlockHeading
-} from './utilities/toolbarHelpers';
+import { toggleMark, toggleBlock, insertThematicBreak,
+  insertLinebreak, insertHeadingbreak, isBlockHeading } from './utilities/toolbarHelpers';
 import { withImages, insertImage } from './plugins/withImages';
 import { withLinks, isSelectionLinkBody } from './plugins/withLinks';
 import { withHtml } from './plugins/withHtml';
@@ -90,7 +89,7 @@ export const MarkdownEditor = (props) => {
       return;
     }
 
-    if (event.key === "Enter" && !isBlockHeading(editor)) {
+    if (event.key === 'Enter' && !isBlockHeading(editor)) {
       return;
     }
 
@@ -129,9 +128,14 @@ export const MarkdownEditor = (props) => {
     const CICERO_MARK_DOM = slateTransformer.toCiceroMark(SLATE_DOM);
     const HTML_DOM = htmlTransformer.toHtml(CICERO_MARK_DOM);
     const MARKDOWN_TEXT = ciceroMarkTransformer.toMarkdown(CICERO_MARK_DOM);
+    const [imageNode] = Editor.nodes(editor, { match: n => n.type === 'image' });
 
     event.clipboardData.setData('text/html', HTML_DOM);
     event.clipboardData.setData('text/plain', MARKDOWN_TEXT);
+
+    if (cut && imageNode) {
+      Editor.deleteBackward(editor);
+    }
 
     if (cut && editor.selection && Range.isExpanded(editor.selection)) {
       Editor.deleteFragment(editor);


### PR DESCRIPTION

# Closes #294 
The Cut operation that can't be performed upon the images is regulated.
### Steps to see the Change
- Click an image
- Press Ctrl+X
- Image disapperas 
- Normal cut functionality

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Related Issues
- Issue #294 
- Pull Request #<NUMBER>

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [x] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
