### PR TITLE
fix(ui-markdown-editor): reading style type of hyper links

### DIFF
--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -14,9 +14,8 @@ import { BUTTON_ACTIVE, BLOCK_STYLE } from './utilities/constants';
 import withSchema from './utilities/schema';
 import Element from './components';
 import Leaf from './components/Leaf';
-import { toggleMark, toggleBlock, insertThematicBreak, 
-  insertLinebreak, insertHeadingbreak, isBlockHeading
-} from './utilities/toolbarHelpers';
+import { toggleMark, toggleBlock, insertThematicBreak,
+  insertLinebreak, insertHeadingbreak, isBlockHeading } from './utilities/toolbarHelpers';
 import { withImages, insertImage } from './plugins/withImages';
 import { withLinks, isSelectionLinkBody } from './plugins/withLinks';
 import { withHtml } from './plugins/withHtml';
@@ -37,7 +36,7 @@ export const MarkdownEditor = (props) => {
     canBeFormatted
   } = props;
   const [showLinkModal, setShowLinkModal] = useState(false);
-  const [currentStyle, setCurrentStyle] = useState('')
+  const [currentStyle, setCurrentStyle] = useState('');
   const editor = useMemo(() => {
     if (augmentEditor) {
       return augmentEditor(
@@ -91,7 +90,7 @@ export const MarkdownEditor = (props) => {
       return;
     }
 
-    if (event.key === "Enter" && !isBlockHeading(editor)) {
+    if (event.key === 'Enter' && !isBlockHeading(editor)) {
       return;
     }
 
@@ -146,7 +145,12 @@ export const MarkdownEditor = (props) => {
     if (selection && isSelectionLinkBody(editor)) {
       setShowLinkModal(true);
     }
-    const currentStyleCalculated = BLOCK_STYLE[Node.parent(editor, editor.selection.focus.path).type] || 'Style';
+    let currentStyleCalculated;
+    if (editor.selection != null) {
+      currentStyleCalculated = BLOCK_STYLE[Node.parent(editor, editor.selection.focus.path).type] || 'Style';
+    } else {
+      currentStyleCalculated = 'Style';
+    }
     setCurrentStyle(currentStyleCalculated);
   };
 


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #296 
If there is no selection made by the editor an error is shown in console.log so added an if else based upon the editor.selection and the error that is shown in console.log disappears.
### Changes
- Added an if else clause to check editor.selection whether selection was made or not.

### Screenshots or Video

### Related Issues
- Issue #296 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [x] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
