### PR TITLE
feat(ui-markdown-editor): heading refactor - #293

### DIFF
--- a/packages/ui-markdown-editor/src/FormattingToolbar/StyleFormat/index.js
+++ b/packages/ui-markdown-editor/src/FormattingToolbar/StyleFormat/index.js
@@ -7,10 +7,13 @@ import {
   DROPDOWN_STYLE,
   DROPDOWN_STYLE_H1,
   DROPDOWN_STYLE_H2,
-  DROPDOWN_STYLE_H3
+  DROPDOWN_STYLE_H3, 
+  DROPDOWN_STYLE_H4,
+  DROPDOWN_STYLE_H5,
+  TOOLBAR_DROPDOWN_STYLE_H6,
 } from '../../utilities/constants';
 import {
-  PARAGRAPH, H1, H2, H3
+  PARAGRAPH, H1, H2, H3, H4, H5, H6
 } from '../../utilities/schema';
 
 const StyleDropdown = ({ canBeFormatted, currentStyle }) => {
@@ -52,6 +55,24 @@ const StyleDropdown = ({ canBeFormatted, currentStyle }) => {
             editor={editor}
             type={H3}
             style={DROPDOWN_STYLE_H3}
+            canBeFormatted={canBeFormatted}
+          />
+          <StyleDropdownItem
+            editor={editor}
+            type={H4}
+            style={DROPDOWN_STYLE_H4}
+            canBeFormatted={canBeFormatted}
+          />
+          <StyleDropdownItem
+            editor={editor}
+            type={H5}
+            style={DROPDOWN_STYLE_H5}
+            canBeFormatted={canBeFormatted}
+          />
+          <StyleDropdownItem
+            editor={editor}
+            type={H6}
+            style={TOOLBAR_DROPDOWN_STYLE_H6}
             canBeFormatted={canBeFormatted}
           />
         </Dropdown.Menu>

--- a/packages/ui-markdown-editor/src/utilities/constants.js
+++ b/packages/ui-markdown-editor/src/utilities/constants.js
@@ -1,7 +1,7 @@
 const MISC_CONSTANTS = {
   DROPDOWN_COLOR: '#122330',
   DROPDOWN_WEIGHT: 'bold',
-  DROPDOWN_NORMAL: 'Normal'
+  DROPDOWN_NORMAL: 'Normal',
 };
 
 export const BUTTON_COLORS = {
@@ -23,6 +23,9 @@ export const BLOCK_STYLE = {
   heading_one: 'Heading 1',
   heading_two: 'Heading 2',
   heading_three: 'Heading 3',
+  heading_four: 'Heading 4',
+  heading_five: 'Heading 5',
+  heading_six: 'Heading 6',
   block_quote: MISC_CONSTANTS.DROPDOWN_NORMAL,
   list_item: MISC_CONSTANTS.DROPDOWN_NORMAL,
   link: MISC_CONSTANTS.DROPDOWN_NORMAL,
@@ -43,38 +46,52 @@ export const DROPDOWN_STYLE_H1 = {
 };
 
 export const DROPDOWN_STYLE_H2 = {
+  fontSize: '25px',
+  lineHeight: '23px',
+  fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
+  color: MISC_CONSTANTS.DROPDOWN_COLOR,
+};
+
+export const DROPDOWN_STYLE_H3 = {
   fontSize: '20px',
   lineHeight: '20px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
   color: MISC_CONSTANTS.DROPDOWN_COLOR,
 };
 
-export const DROPDOWN_STYLE_H3 = {
-  fontSize: '16px',
-  lineHeight: '16px',
-  fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
-  color: MISC_CONSTANTS.DROPDOWN_COLOR,
-};
-
 export const DROPDOWN_STYLE_H4 = {
-  fontSize: '15px',
-  lineHeight: '15px',
+  fontSize: '18px',
+  lineHeight: '18px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
   color: MISC_CONSTANTS.DROPDOWN_COLOR,
 };
 
 export const DROPDOWN_STYLE_H5 = {
-  fontSize: '14x',
-  lineHeight: '14px',
+  fontSize: '16x',
+  lineHeight: '16px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
   color: MISC_CONSTANTS.DROPDOWN_COLOR,
 };
 
 export const DROPDOWN_STYLE_H6 = {
-  fontSize: '13px',
-  lineHeight: '13px',
+  fontSize: '14px',
+  lineHeight: '14px',
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
-  color: MISC_CONSTANTS.DROPDOWN_COLOR,
+  color: '#949CA2',
+  letterSpacing: '0.3px',
+  // This margin is to override default styling in chrome
+  margin: '0.7rem 0rem 1rem 0rem',
+  textTransform: 'uppercase',
+};
+
+// Separate styling for the toolbar without margin to make it look normal
+export const TOOLBAR_DROPDOWN_STYLE_H6 = {
+  fontSize: '14px',
+  lineHeight: '14px',
+  fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
+  color: '#949CA2',
+  letterSpacing: '0.3px',
+  textTransform: 'uppercase',
 };
 
 export const POPUP_STYLE = {

--- a/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
+++ b/packages/ui-markdown-editor/src/utilities/toolbarHelpers.js
@@ -1,6 +1,6 @@
 import { Node, Editor, Transforms } from 'slate';
 import {
-  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH, HEADINGS
+  LIST_ITEM, BLOCK_QUOTE, LIST_TYPES, PARAGRAPH, HEADINGS, H1, H2, H3, H4, H5, H6
 } from './schema';
 
 export const isBlockActive = (editor, format) => {
@@ -112,9 +112,12 @@ export const insertHeadingbreak = (editor) => {
 export const isBlockHeading = (editor) => {
   const [match] = Editor.nodes(editor, {
     match: n => { 
-      return n.type === 'heading_one'
-        || n.type === 'heading_two'
-        || n.type === 'heading_three'
+      return n.type === H1
+        || n.type === H2
+        || n.type === H3
+        || n.type === H4
+        || n.type === H5
+        || n.type === H6
     },
   });
   return !!match;


### PR DESCRIPTION
Signed-off-by: d-e-v-esh <59534570+d-e-v-esh@users.noreply.github.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #293
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added Heading 4, Heading 5, and Heading 6 and change font sizes of existing heading in the following manner:
- `Heading 1` = 25px => Stays the same
- `Heading 2` = 25px => Left-aligned to differentiate from H1
- `Heading 3` = 20px
- `Heading 4` = 18px
- `Heading 5` = 16px
- `Heading 6` = 14px => Same size as a normal paragraph, All capital letters, The same text formatting as the text used in Page Break
- Added new headings in the `isBlockHeading` function that tells if a block is heading or not.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- There are few problems existing in the headings especially `Heading 6`. This is basically occurring because a few of the CSS properties are not defined so to make things look better, web browsers add them by default under [user agent stylesheet](https://stackoverflow.com/questions/12582624/what-is-a-user-agent-stylesheet).
- This problem was messing up the styling of Heading 6 but this is good enough for a fix for now. This is not optimal because overriding properties of few elements and not all create a mismatch. An optimal fix would require discussing what would be the best values for the missing properties and then adding them so everything is in our control. See comments in #293
- We can create a separate issue for that and I can work on it then if that sounds good.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

![cU8uqozyuj](https://user-images.githubusercontent.com/59534570/111065052-a8d37000-84dd-11eb-8cd5-45172fae3e24.gif)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [x] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [x] Appropriate labels, alt text, and instructions
