### PR TITLE
fix(ui-markdown-editor): hyperlink markdown text conversion - #301

### DIFF
--- a/packages/ui-markdown-editor/src/plugins/withLinks.js
+++ b/packages/ui-markdown-editor/src/plugins/withLinks.js
@@ -48,8 +48,11 @@ const wrapLink = (editor, url, text) => {
     Transforms.insertNodes(editor, link);
     return;
   }
-  unwrapLink(editor);
-  Transforms.wrapNodes(editor, link, { split: true });
+  if(isSelectionLink(editor)){
+    unwrapLink(editor);
+  }
+  Editor.deleteBackward(editor);
+  Transforms.insertNodes(editor, link);
 };
 
 export const insertLink = (editor, url, text) => {


### PR DESCRIPTION
Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #301<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Creating a hyperlink by selecting the text now changes the text in the markdown.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Delete the current selection
- <TWO> Insert the node with updated parameters.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
##### Before
https://www.loom.com/share/6eb14ef12e6243c2bf7ad810f1795240

##### Now
https://www.loom.com/share/8c31c14ea6e8468b852b272a1f3aed49

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
