### PR TITLE
fix(ui-contract-editor): styling dropdown - #278

### DIFF
--- a/packages/ui-markdown-editor/src/FormattingToolbar/ToolbarMenu.js
+++ b/packages/ui-markdown-editor/src/FormattingToolbar/ToolbarMenu.js
@@ -5,6 +5,7 @@ const Menu = styled.div`
   position: sticky;
   top: 0;
   width: 100%;
+  z-index: 10;
   min-width: 600px;
   background-color: #FFF;
   padding: 15px 15px 5px 15px;
@@ -19,7 +20,6 @@ const Menu = styled.div`
   & > * + * {
     margin-left: 15px;
   }
-  };
 `;
 
 const ToolbarMenu = React.forwardRef(


### PR DESCRIPTION
Signed-off-by: d-e-v-esh <59534570+d-e-v-esh@users.noreply.github.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #278 
<!--- Provide an overall summary of the pull request -->
The styling dropdown was being obscured by the clause template. This fixes the issue by pulling up the z-index of the toolbar so that it appears above the template.


### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added a `z-index` to the toolbar
- Removed a dead closing curly brace that was probably left there mistakenly as there was no opening bracket and it was giving out a red line.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
- We probably need to organize the `z-index` of all the elements in order to avoid confusion in the future. This is how it looks like.


![Code_cbiurwMflw](https://user-images.githubusercontent.com/59534570/111190676-57120f00-85dd-11eb-914d-6605e842f722.png)


### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
The issue is resolved.


![iktSFqM9BZ](https://user-images.githubusercontent.com/59534570/111190409-10241980-85dd-11eb-8d19-56037c8721aa.gif)



### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [x] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [x] Appropriate labels, alt text, and instructions
