### PR TITLE
fix(ui-markdown-editor): Resize clickable area - #318

### DIFF
--- a/packages/ui-markdown-editor/src/components/icons/image.js
+++ b/packages/ui-markdown-editor/src/components/icons/image.js
@@ -12,8 +12,9 @@ const icon = () => (
 const image = {
   type: 'image',
   label: `Insert Image (${MOD()}+Shift+G)`,
-  height: '18px',
-  width: '18px',
+  height: '25px',
+  width: '25px',
+  padding: '4px',
   viewBox: '0 0 18 18',
   icon,
 };

--- a/packages/ui-markdown-editor/src/components/icons/tbreak.js
+++ b/packages/ui-markdown-editor/src/components/icons/tbreak.js
@@ -13,8 +13,9 @@ const icon = () => (
 const tbreak = {
   type: 'horizontal_rule',
   label: `Page Break (${MOD()}+Enter)`,
-  height: '17px',
-  width: '17px',
+  height: '25px',
+  width: '25px',
+  padding: '4px',
   viewBox: '0 0 19 19',
   icon,
 };


### PR DESCRIPTION
Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #318 <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Clickable area increased of page break and image icons.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Updated the width and padding of the icons

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

**The height of different icons**
![Screenshot from 2021-03-25 12-39-23](https://user-images.githubusercontent.com/59891164/112433100-cb7c4900-8d67-11eb-8cde-413d06c31b0e.png)
![Screenshot from 2021-03-25 12-39-18](https://user-images.githubusercontent.com/59891164/112433109-cddea300-8d67-11eb-966a-c31647068d42.png)
![Screenshot from 2021-03-25 12-39-14](https://user-images.githubusercontent.com/59891164/112433116-cfa86680-8d67-11eb-889e-b248ee7582c4.png)
![Screenshot from 2021-03-25 12-39-10](https://user-images.githubusercontent.com/59891164/112433123-d1722a00-8d67-11eb-8683-e5d428cfe5e3.png)

**Hovering over the icon**
![Screenshot from 2021-03-25 12-39-05](https://user-images.githubusercontent.com/59891164/112433129-d33bed80-8d67-11eb-85ff-f30dffae7c47.png)
![Screenshot from 2021-03-25 12-38-46](https://user-images.githubusercontent.com/59891164/112433136-d46d1a80-8d67-11eb-8b98-720bd4e137d2.png)
![Screenshot from 2021-03-25 12-38-44](https://user-images.githubusercontent.com/59891164/112433142-d6cf7480-8d67-11eb-8ca8-65eaf3f21ec9.png)


### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
