### PR TITLE
fix(ui-markdown-editor): allow image deletion - #320

### DIFF
--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -85,6 +85,20 @@ export const MarkdownEditor = (props) => {
       return;
     }
 
+    const [imageNode] = Editor.nodes(editor, { match: n => n.type === 'image' });
+
+    // handle specific case to delete image when backspace is pressed
+    if(event.keyCode===8 && imageNode){
+      Editor.deleteBackward(editor);
+      return ;
+    }
+
+    // handle specific case to delete image when delete is pressed
+    if(event.keyCode===46 && imageNode){
+      Editor.deleteForward(editor);
+      return ;
+    }
+
     const isFormatEvent = () => formattingHotKeys.some(hotkey => isHotkey(hotkey, event));
     if (!canBeFormatted(editor) && isFormatEvent()) {
       event.preventDefault();


### PR DESCRIPTION
Signed-off-by: k-kumar-01 <kushalkumargupta4@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #320 <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
Image can be deleted now by pressing either the backspace key or the delete key.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Check if the key is backspace and node selected is image. If `true` delete the use `Editor.deleteBackward(editor)`
- <TWO> Check if the key is delete and node selected is image. If `true` delete the use `Editor.deleteFordward(editor)`

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
