### PR TITLE
Catch onChange exceptions for issue #335

### DIFF
--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -37,7 +37,7 @@ export const MarkdownEditor = (props) => {
     canBeFormatted
   } = props;
   const [showLinkModal, setShowLinkModal] = useState(false);
-  const [currentStyle, setCurrentStyle] = useState('')
+  const [currentStyle, setCurrentStyle] = useState('');
   const editor = useMemo(() => {
     if (augmentEditor) {
       return augmentEditor(
@@ -145,14 +145,18 @@ export const MarkdownEditor = (props) => {
   }, [canCopy, editor]);
 
   const onChange = (value) => {
-    if (props.readOnly) return;
-    props.onChange(value, editor);
-    const { selection } = editor;
-    if (selection && isSelectionLinkBody(editor)) {
-      setShowLinkModal(true);
+    try {
+      if (props.readOnly) return;
+      props.onChange(value, editor);
+      const { selection } = editor;
+      if (selection && isSelectionLinkBody(editor)) {
+        setShowLinkModal(true);
+      }
+      const currentStyleCalculated = BLOCK_STYLE[Node.parent(editor, editor.selection.focus.path).type] || 'Style';
+      setCurrentStyle(currentStyleCalculated);
+    } catch (err) {
+      console.log('Caught exception within markdown-editor onChange', err);
     }
-    const currentStyleCalculated = BLOCK_STYLE[Node.parent(editor, editor.selection.focus.path).type] || 'Style';
-    setCurrentStyle(currentStyleCalculated);
   };
 
   const handleDragStart = (event) => {


### PR DESCRIPTION
Signed-off-by: Dan Selman <danscode@selman.org>

# Closes #335

Catches exceptions raised by the `onChange` handler registered with the markdown-editor, preventing them from crashing the editor.

### Changes
- Wrap `onChange` in try/catch and log to the console

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
