### PR TITLE
feat(ui-markdown-editor): inline-code BG - #341

### DIFF
--- a/packages/ui-markdown-editor/src/components/Leaf.js
+++ b/packages/ui-markdown-editor/src/components/Leaf.js
@@ -1,5 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Code = styled.code`
+  color: black;
+  border: 1px solid #D3D3D3;
+  background: #ededeb;
+  border-radius: 2.5px;
+  padding: 0px 2px;
+`;
 
 /* eslint no-param-reassign: 0 */
 const Leaf = ({ attributes, children, leaf }) => {
@@ -8,7 +17,7 @@ const Leaf = ({ attributes, children, leaf }) => {
   }
 
   if (leaf.code) {
-    children = <code>{children}</code>;
+    children = <Code>{children}</Code>;
   }
 
   if (leaf.italic) {


### PR DESCRIPTION
Signed-off-by: Devesh <deves125@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #341
<!--- Provide an overall summary of the pull request -->
This pull request adds a light grey background color to the inline code area.


## Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- Added a light grey background to the inline code.
- Added a very thin `1px` border to that `inline_code` area and `2.5px` border-radius.




## Screenshots or Video

### Now
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![chrome_4h2qhz7bwg](https://user-images.githubusercontent.com/59534570/117840672-009e1580-b29a-11eb-87b5-b18a1c7db87b.png)

### Before
![chrome_xqWH7uKXjo](https://user-images.githubusercontent.com/59534570/117842420-89698100-b29b-11eb-80ed-a9d2100509b6.png)




### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [x] Appropriate labels, alt text, and instructions
