### PR TITLE
feat(ui-markdown-editor): heading wysiwyg - #346

### DIFF
--- a/packages/ui-markdown-editor/src/plugins/withText.js
+++ b/packages/ui-markdown-editor/src/plugins/withText.js
@@ -1,9 +1,8 @@
-import { Editor, Node } from 'slate';
-import { insertThematicBreak, isBlockHeading } from '../utilities/toolbarHelpers';
-import { HR } from '../utilities/schema'
+import { Node } from 'slate';
+import { isBlockHeading } from '../utilities/toolbarHelpers';
+import { matchCases } from "utilities/matchCases";
 
 export const withText = (editor) => {
-  // Inserts page break with dash
 	const { insertText } = editor;
 	editor.insertText = (text) => {
 		insertText(text);
@@ -11,12 +10,8 @@ export const withText = (editor) => {
 		if(isBlockHeading(editor)){
 			return;
 		}
-		const firstWord = currentNode.text;
-		if(firstWord !== '---'){
-			return;
-		}
-		Editor.deleteBackward(editor, { unit: 'word' });
-		insertThematicBreak(editor, HR);
+		const currentLine = currentNode.text;
+		matchCases(editor, currentLine);
 	}
 	return editor;
 }

--- a/packages/ui-markdown-editor/src/utilities/matchCases.js
+++ b/packages/ui-markdown-editor/src/utilities/matchCases.js
@@ -1,0 +1,35 @@
+import { Transforms, Editor } from 'slate';
+import { H1, H2, H3, H4, H5, H6, HR } from "./schema";
+import { insertThematicBreak } from "./toolbarHelpers";
+
+export const matchCases = (editor, currentLine) => {
+
+	const matchHeadings = (editor, currentLine) => {
+		const headingMatchCase = currentLine.match(/(^\s*)#{1,6}\s/m);
+		if(!headingMatchCase) return;
+
+		const count = (headingMatchCase[0].match(/#/g) || []).length;
+		if (count === 1) Transforms.setNodes(editor, { type: H1 });
+		else if (count === 2) Transforms.setNodes(editor, { type: H2 });
+		else if (count === 3) Transforms.setNodes(editor, { type: H3 });
+		else if (count === 4) Transforms.setNodes(editor, { type: H4 });
+		else if (count === 5) Transforms.setNodes(editor, { type: H5 });
+		else if (count === 6) Transforms.setNodes(editor, { type: H6 });
+
+		Editor.deleteBackward(editor, { unit: 'word' });
+		return;
+	}
+
+	const matchPageBreak = (editor, currentLine)=>{
+		const pageBreakMatchCase = currentLine.match(/(^\s*)([*-])(?:[\t ]*\2){2,}/m);
+		if(!pageBreakMatchCase) return
+
+		Editor.deleteBackward(editor, { unit: 'word' });
+		insertThematicBreak(editor, HR);
+
+		return;
+	}
+
+	matchHeadings(editor, currentLine);
+	matchPageBreak(editor, currentLine);
+}


### PR DESCRIPTION
Signed-off-by: Devesh <deves125@gmail.com>

<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #346
### This is an improvement over #347
<!--- Provide an overall summary of the pull request -->
This pull request adds the feature of markdown shortcuts for headings. Now we can insert headings in the document with the help of just the `#`.
 - \# => H1
 - \## => H2
 - \### => H3
 - \#### => H4
 - \##### => H5
 - \######=> H6
 - ---,  - - -, ***, * * * => PageBreak

- This is a refactor to the #347 which was suggested by @dselman [here](https://github.com/accordproject/web-components/pull/347#discussion_r634371097).
- I could be wrong in understanding what Dan was saying. I want to get the opinions of Dan and other mentors on how to implement the structure for the `matchCases` so it becomes very easy to implement more matching functions later in the future.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->

- <ONE> A file called `matchCases` is added inside the `utilities` folder. This file is supposed to contain all the upcoming match cases that would be added i.e. code block, ordered and unordered lists, bold, italics etc.
- A bug in the existing page break shortcut was fixed where it would keep the line where we inserted the `---`.


### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
![bJhepTiT0z](https://user-images.githubusercontent.com/59534570/118138054-85686b00-b423-11eb-89fe-065b22e95643.gif)


### Related Issues
- Issue #321

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [x] Appropriate labels, alt text, and instructions
