### PR TITLE
feat(ui-components): filter templates by cicero version - #67

### DIFF
--- a/packages/storybook/src/stories/7-Library.stories.js
+++ b/packages/storybook/src/stories/7-Library.stories.js
@@ -92,6 +92,7 @@ export const heterogeneous = () => {
       ),
       name: text("First template's Name", "Acceptance of Delivery"),
       version: text("First template's Version", "0.20.10"),
+      CiceroVersion: text("First template's Cicero Version", "0.22.0"),
       description: text(
         "First template's Description",
         "This clause allows the receiver of goods to inspect them for a given time period after delivery."
@@ -103,6 +104,7 @@ export const heterogeneous = () => {
         "variable://first-variable-item@0.10.1#fc26b60d5cb6c23c4e85ea643a6931bca96c42ec94e467df522d80fb79864353",
       name: "First variable item",
       version: "0.20.1",
+      CiceroVersion: "0.21.0",
       description: "This is a sample variable item",
       itemType: 'variable'
     },
@@ -111,6 +113,7 @@ export const heterogeneous = () => {
         "https://templates.accordproject.org/archives/car-rental-tr@0.10.1.cta",
       name: "Car Rental (TR)",
       version: "0.20.10",
+      CiceroVersion: "0.21.0",
       description: "Ta Simple Car Rental Contract in Turkish Language",
       itemType: 'template'
     },


### PR DESCRIPTION
Signed-off-by: TC5022 <tanyac5022002@gmail.com>

# Closes #67 
Added a dropdown that filters templates based on their cicero version.

### Changes
Added a filter that uses the cicero version of the templates by building on PR [#187](https://github.com/accordproject/web-components/pull/187). 
- <ONE> Added a cicero version in the items data in the library component after confirming that the metadata from templates contains their corresponding cicero version as can be seen [here](https://github.com/accordproject/cicero-template-library/blob/master/views/template.njk#L32).
- <TWO> Styled a dropdown for the same.
- <THREE> The filter works even if some of the items in the library do not return a cicero version. This can be confirmed through the demo itself because one of the items in the data does not contain a cicero version


### Screenshots or Video
![image](https://user-images.githubusercontent.com/75262300/150183948-201661b6-4e9f-4e88-b764-e2bc431d8588.png)
![image](https://user-images.githubusercontent.com/75262300/150184028-25ddc063-ef66-4830-84b7-bde08ea652f1.png)


### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
