### PR TITLE
chore(github) - add action to deploy to AWS S3

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Build & test 
         if: github.ref == 'refs/heads/master'
         run: |
-            npx lerna bootstrap
-            npx lerna run build
-            npm run build --if-present
-            npm test
+            npm install -g lerna
+            lerna bootstrap
+            lerna run build
+            npm run storybook
 
       - name: Set S3 
         if: github.ref == 'refs/heads/master'
@@ -57,7 +57,7 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks --delete
         env:
-          SOURCE_DIR: 'packages/storybook'
+          SOURCE_DIR: 'packages/storybook/storybook-static'
 
       - name: Invalidate Cloudfront
         uses: chetan/invalidate-cloudfront-action@master

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,67 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: actions/cache@v2
+        id: npm-and-build-cache
+        with:
+          path: |
+            ~/.cache/Cypress
+            build
+            node_modules
+          key: ${{ runner.os }}-node_modules-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-build-
+
+      - name: Build & test 
+        if: github.ref == 'refs/heads/master'
+        run: |
+            npx lerna bootstrap
+            npx lerna run build
+            npm run build --if-present
+            npm test
+
+      - name: Set S3 
+        if: github.ref == 'refs/heads/master'
+        run: |
+            echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
+
+      - name: Deploy to S3
+        if: github.ref == 'refs/heads/master'
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          SOURCE_DIR: 'packages/storybook'
+
+      - name: Invalidate Cloudfront
+        uses: chetan/invalidate-cloudfront-action@master
+        env:
+          DISTRIBUTION: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
+          PATHS: '/*'
+          AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
Creates an GitHub "Action" to build and deploy to AWS S3.

Requires the following "SECRETS" to be specified in GitHub.

AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_S3_BUCKET
Will need to add the following secrets to the repo.

AWS_CLOUDFRONT_DISTRIBUTION_ID : EHOZMSZP988SV
AWS_REGION : us-east-1
The invalidation is created after each deployment to S3 and can be seen here:
https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/EHOZMSZP988SV/invalidations

The S3 Bucket URL for testing is:
http://web-components.accordproject.org.s3-website-us-east-1.amazonaws.com/

The CloudFront Distro URL for testing is:
https://d39ci3wc10irbe.cloudfront.net/