### PR TITLE
feat(ui-markdown-editor): add support for tables-#39

### DIFF
--- a/packages/ui-markdown-editor/src/FormattingToolbar/TableModal.js
+++ b/packages/ui-markdown-editor/src/FormattingToolbar/TableModal.js
@@ -1,0 +1,322 @@
+import React, { useEffect, useCallback, useState } from "react";
+import PropTypes from "prop-types";
+import { ReactEditor, useEditor } from "slate-react";
+import { Editor, Transforms, Range, Element } from "slate";
+import styled from "styled-components";
+import { Form, Input, Popup } from "semantic-ui-react";
+
+import Portal from "../components/Portal";
+import { insertTable, handleCells, isSelectionTable } from "plugins/withTables";
+
+import RowIcon from "../components/icons/row";
+import ColumnIcon from "../components/icons/col";
+import DeleteIcon from "../components/icons/deleteTable";
+import DeleteRowIcon from "../components/icons/deleteRow";
+import DeleteColIcon from "../components/icons/deleteCol";
+
+const TableModalWrapper = styled.div`
+  position: absolute;
+  z-index: 3000;
+  top: -10000px;
+  left: -10000px;
+  margin-top: -6px;
+  opacity: 0;
+  background-color: #ffffff;
+  border: 1px solid #d4d4d5;
+  border-radius: 0.3rem;
+  line-height: 1.4285em;
+  max-width: 300px;
+  padding: 0.833em 1em;
+  font-weight: 400;
+  font-style: normal;
+  color: rgba(0, 0, 0, 0.87);
+  box-shadow: 0 2px 4px 0 rgba(34, 36, 38, 0.12),
+    0 2px 10px 0 rgba(34, 36, 38, 0.15);
+  & > * {
+    display: inline-block;
+  }
+`;
+
+const TableModalCaret = styled.div`
+  position: absolute;
+  z-index: 4000;
+  left: calc(50% - 5px);
+  top: -10px;
+  height: 0;
+  width: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 10px solid #d4d4d5;
+  transition: opacity 0.75s;
+`;
+
+const TableIconHolder = styled.div`
+  cursor: pointer;
+  width: 25px;
+  height: 25px;
+  border-radius: 3px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  padding: -2px 3px;
+  margin: 5px;
+  &:hover {
+    background-color: #eee;
+  }
+`;
+
+const InlineFormField = styled(Form.Field)`
+  display: flex;
+  flex-direction: row;
+`;
+
+const InputFieldWrapper = styled.div`
+  width: 270px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const InputFieldLabel = styled.label`
+  font-weight: bold;
+  font-size: 12px;
+`;
+
+const InlineFormButton = styled.button`
+  margin-left: 10px;
+  align-self: flex-end;
+  height: 38px;
+  width: 90px;
+  border: none;
+  color: #fff;
+  border-radius: 3px;
+  background-color: #0043ba;
+  &:hover {
+    background-color: #265fc4;
+  }
+`;
+
+const popupStyles = {
+  padding: "0.2em 0.5em 0.2em 0.5em",
+  zIndex: "9999",
+};
+
+const TableMenu = React.forwardRef(({ ...props }, ref) => (
+  <TableModalWrapper ref={ref} {...props} />
+));
+
+TableMenu.displayName = "TableMenu";
+
+const TableModal = React.forwardRef(({ ...props }, ref) => {
+  const editor = useEditor();
+  const [originalSelection, setOriginalSelection] = useState(null);
+  const [rows, setRows] = useState(1);
+  const [cols, setCols] = useState(1);
+
+  const actionHandler = useCallback(
+    (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        props.setShowTableModal(false);
+      }
+    },
+    [props, ref]
+  );
+
+  useEffect(() => {
+    document.addEventListener("mousedown", actionHandler);
+    document.addEventListener("keydown", actionHandler);
+    return () => {
+      document.removeEventListener("mousedown", actionHandler);
+      document.removeEventListener("keydown", actionHandler);
+    };
+  }, [actionHandler]);
+
+  useEffect(() => {
+    if (props.showTableModal) {
+      setOriginalSelection(editor.selection);
+      const x = window.scrollX;
+      const y = window.scrollY;
+      window.scrollTo(x, y);
+    }
+  }, [editor, props.showTableModal]);
+
+  /**
+   * Inserts the table in the document.
+   */
+  const createTable = () => {
+    Transforms.select(editor, originalSelection);
+    insertTable(editor, rows, cols);
+    Transforms.collapse(editor, { edge: "end" });
+    ReactEditor.focus(editor);
+    props.setShowTableModal(false);
+  };
+
+  /**
+   * Inserts and Deletes rows and columns from the table
+   *  @param {string} action action to be performed
+   */
+  const handleClick = (action) => {
+    Transforms.select(editor, originalSelection);
+
+    const { selection } = editor;
+    if (!!selection && Range.isCollapsed(selection)) {
+      const [tableNode] = Editor.nodes(editor, {
+        match: (n) =>
+          !Editor.isEditor(n) && Element.isElement(n) && n.type === "table",
+      });
+      if (tableNode) {
+        const [oldTable, path] = tableNode;
+        removeTable(editor);
+        if (action === "row") {
+          handleCells(oldTable, path, "row", editor);
+        } else if (action === "col") {
+          handleCells(oldTable, path, "col", editor);
+        } else if (action === "drow") {
+          handleCells(oldTable, path, "drow", editor);
+        } else {
+          handleCells(oldTable, path, "dcol", editor);
+        }
+      }
+    }
+
+    Transforms.deselect(editor);
+    ReactEditor.focus(editor);
+    props.setShowTableModal(false);
+  };
+
+  /**
+   * Deletes the table from the document.
+   */
+  const removeTable = () => {
+    Transforms.select(editor, originalSelection);
+    Transforms.removeNodes(editor, {
+      match: (n) =>
+        !Editor.isEditor(n) && Element.isElement(n) && n.type === "table",
+      mode: "highest",
+    });
+
+    Transforms.deselect(editor);
+    ReactEditor.focus(editor);
+    props.setShowTableModal(false);
+  };
+
+  return (
+    <Portal>
+      <TableMenu ref={ref}>
+        <TableModalCaret />
+        <Form onSubmit={createTable}>
+          {!isSelectionTable(editor) && (
+            <InputFieldWrapper>
+              <InputFieldLabel>Number of rows</InputFieldLabel>
+              <Input
+                placeholder="Rows"
+                name="rows"
+                type="number"
+                min="1"
+                value={rows}
+                onChange={(e) => setRows(e.target.value)}
+              />
+            </InputFieldWrapper>
+          )}
+          {!isSelectionTable(editor) && (
+            <InlineFormField>
+              <InputFieldWrapper>
+                <InputFieldLabel>Number of columns</InputFieldLabel>
+                <Input
+                  placeholder="Columns"
+                  name="columns"
+                  type="number"
+                  min="1"
+                  value={cols}
+                  onChange={(e) => setCols(e.target.value)}
+                />
+              </InputFieldWrapper>
+              <InlineFormButton type="submit">Create Table</InlineFormButton>
+            </InlineFormField>
+          )}
+
+          <InlineFormField>
+            <Popup
+              trigger={
+                <TableIconHolder
+                  onClick={() => handleClick("row")}
+                  aria-label="Insert new row"
+                >
+                  <RowIcon />
+                </TableIconHolder>
+              }
+              content="Insert new row"
+              inverted
+              position="bottom left"
+              style={popupStyles}
+            />
+            <Popup
+              trigger={
+                <TableIconHolder
+                  onClick={() => handleClick("col")}
+                  aria-label="Insert new column"
+                >
+                  <ColumnIcon />
+                </TableIconHolder>
+              }
+              content="Insert new column"
+              inverted
+              position="bottom left"
+              style={popupStyles}
+            />
+            <Popup
+              trigger={
+                <TableIconHolder
+                  onClick={() => handleClick("drow")}
+                  aria-label="Delete a row"
+                >
+                  <DeleteRowIcon />
+                </TableIconHolder>
+              }
+              content="Delete a row"
+              inverted
+              position="bottom left"
+              style={popupStyles}
+            />
+            <Popup
+              trigger={
+                <TableIconHolder
+                  onClick={() => handleClick("dcol")}
+                  aria-label="Delete a column"
+                >
+                  <DeleteColIcon />
+                </TableIconHolder>
+              }
+              content="Delete a column"
+              inverted
+              position="bottom left"
+              style={popupStyles}
+            />
+            <Popup
+              trigger={
+                <TableIconHolder
+                  onClick={removeTable}
+                  aria-label="Delete table"
+                >
+                  <DeleteIcon />
+                </TableIconHolder>
+              }
+              content="Delete table"
+              inverted
+              position="bottom left"
+              style={popupStyles}
+            />
+          </InlineFormField>
+        </Form>
+      </TableMenu>
+    </Portal>
+  );
+});
+
+TableModal.displayName = "TableModal";
+
+TableModal.propTypes = {
+  setShowTableModal: PropTypes.func,
+  showTableModal: PropTypes.bool,
+};
+
+export default TableModal;

--- a/packages/ui-markdown-editor/src/FormattingToolbar/index.js
+++ b/packages/ui-markdown-editor/src/FormattingToolbar/index.js
@@ -4,6 +4,7 @@ import { ReactEditor, useEditor } from 'slate-react';
 import { Transforms } from 'slate';
 
 import { InsertImageButton } from '../plugins/withImages';
+import { InsertTableButton } from 'plugins/withTables';
 import ToolbarMenu from './ToolbarMenu';
 import FormatButton from './FormatButton';
 import InsertButton from './InsertButton';
@@ -11,6 +12,7 @@ import HistoryButton from './HistoryButton';
 import HyperlinkButton from './HyperlinkButton';
 import StyleDropdown from './StyleFormat';
 import HyperlinkModal from './HyperlinkModal';
+import TableModal from './TableModal';
 import {
   toggleBlock, isBlockActive,
   toggleMark, isMarkActive,
@@ -20,7 +22,7 @@ import {
   bold, italic, code,
   quote, olist, ulist,
   image, link, undo, redo,
-  tbreak, Separator
+  tbreak, Separator, table
 } from '../components/icons';
 
 const mark = { toggleFunc: toggleMark, activeFunc: isMarkActive };
@@ -33,10 +35,13 @@ const FormattingToolbar = ({
   showLinkModal,
   setShowLinkModal,
   activeButton,
-  currentStyle
+  currentStyle,
+  showTableModal,
+  setShowTableModal
 }) => {
   const editor = useEditor();
   const linkModalRef = useRef();
+  const tableModalRef = useRef();
 
   const buttonProps = {
     canBeFormatted,
@@ -48,9 +53,14 @@ const FormattingToolbar = ({
     setShowLinkModal
   };
 
+  const tableProps = {
+    showTableModal,
+    setShowTableModal
+  }
+
   useEffect(() => {
-    if (showLinkModal) {
-      const el = linkModalRef.current;
+    if (showLinkModal || showTableModal) {
+      const el = showLinkModal ? linkModalRef.current : tableModalRef.current;
       const domRange = ReactEditor.toDOMRange(editor, editor.selection);
       const rect = domRange.getBoundingClientRect();
       const CARET_TOP_OFFSET = 15;
@@ -85,7 +95,7 @@ const FormattingToolbar = ({
 
       el.style.left = `${calPos}px`;
     }
-  }, [editor, showLinkModal]);
+  }, [editor, showLinkModal, showTableModal]);
 
   return (
     <ToolbarMenu id="ap-rich-text-editor-toolbar">
@@ -105,7 +115,9 @@ const FormattingToolbar = ({
       <HyperlinkButton {...linkProps} {...link} {...buttonProps} />
       <InsertImageButton {...image} canBeFormatted={canBeFormatted} />
       <InsertButton {...insert} {...tbreak} canBeFormatted={canBeFormatted} />
+      <InsertTableButton {...table} {...tableProps} canBeFormatted={canBeFormatted} />
       { showLinkModal && <HyperlinkModal ref={linkModalRef} {...linkProps} /> }
+      {showTableModal && <TableModal ref={tableModalRef} {...tableProps}  />}
     </ToolbarMenu>
   );
 };

--- a/packages/ui-markdown-editor/src/components/icons/col.js
+++ b/packages/ui-markdown-editor/src/components/icons/col.js
@@ -1,0 +1,44 @@
+import React from "react";
+
+/**
+ * Renders the icon for inserting column in svg format.
+ *
+ * @returns {HTMLOrSVGElement} SVG for the Insert column icon
+ */
+
+export default () => (
+  <div>
+    <svg
+      width="20px"
+      height="20px"
+      viewBox="0 0 1024 1024"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        id="Old-pages"
+        stroke="none"
+        strokeWidth="1"
+        fill="none"
+        fillRule="evenodd"
+      >
+        <g id="Hyperlink-UI" transform="translate(-15.000000, -162.000000)">
+          <g id="Group-6" transform="translate(0.000000, 2.000000)">
+            <g
+              id="ic_content_copy_24px"
+              transform="translate(14.000000, 160.071068)"
+            >
+              <polygon id="Path" />
+              <path
+                d="M856 112h-80c-4.4 0-8 3.6-8 8v784c0 4.4 3.6 8 8 8h80c4.4 0 8-3.6 8-8V120c0-4.4-3.6-8-8-8zM656 112H192c-17.7 0-32 14.9-32 33.3v733.3c0 18.4 14.3 33.3 32 33.3h464c17.7 0 32-14.9 32-33.3V145.3c0-18.4-14.3-33.3-32-33.3zM392 840H232V664h160v176z m0-240H232V424h160v176z m0-240H232V184h160v176z m224 480H456V664h160v176z m0-240H456V424h160v176z m0-240H456V184h160v176z"
+                id="Shape"
+                fill="#959CA3"
+                fillRule="nonzero"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+);

--- a/packages/ui-markdown-editor/src/components/icons/deleteCol.js
+++ b/packages/ui-markdown-editor/src/components/icons/deleteCol.js
@@ -1,0 +1,44 @@
+import React from "react";
+
+/**
+ * Renders the icon for deleting column in svg format.
+ *
+ * @returns {HTMLOrSVGElement} SVG for the Delete column icon
+ */
+
+export default () => (
+  <div>
+    <svg
+      width="20px"
+      height="20px"
+      viewBox="0 0 1024 1024"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        id="Old-pages"
+        stroke="none"
+        strokeWidth="1"
+        fill="none"
+        fillRule="evenodd"
+      >
+        <g id="Hyperlink-UI" transform="translate(-15.000000, -162.000000)">
+          <g id="Group-6" transform="translate(0.000000, 2.000000)">
+            <g
+              id="ic_content_copy_24px"
+              transform="translate(14.000000, 160.071068)"
+            >
+              <polygon id="Path" />
+              <path
+                d="M819.8 512l102.4-122.9c2.8-3.4 2.4-8.4-1-11.3-1.4-1.2-3.2-1.9-5.1-1.9h-54.7c-2.4 0-4.6 1.1-6.1 2.9L782 466.7l-73.1-87.8c-1.5-1.8-3.8-2.9-6.1-2.9H648c-1.9 0-3.7 0.7-5.1 1.9-3.4 2.8-3.9 7.9-1 11.3L744.2 512 641.8 634.9c-2.8 3.4-2.4 8.4 1 11.3 1.4 1.2 3.2 1.9 5.1 1.9h54.7c2.4 0 4.6-1.1 6.1-2.9l73.1-87.8 73.1 87.8c1.5 1.8 3.8 2.9 6.1 2.9h55c1.9 0 3.7-0.7 5.1-1.9 3.4-2.8 3.9-7.9 1-11.3L819.8 512zM536 464H120c-4.4 0-8 3.6-8 8v80c0 4.4 3.6 8 8 8h416c4.4 0 8-3.6 8-8v-80c0-4.4-3.6-8-8-8zM452 668h-60c-3.3 0-6 2.7-6 6v166H136c-3.3 0-6 2.7-6 6v60c0 3.3 2.7 6 6 6h292c16.6 0 30-13.4 30-30V674c0-3.3-2.7-6-6-6zM136 184h250v166c0 3.3 2.7 6 6 6h60c3.3 0 6-2.7 6-6V142c0-16.6-13.4-30-30-30H136c-3.3 0-6 2.7-6 6v60c0 3.3 2.7 6 6 6z"
+                id="Shape"
+                fill="#959CA3"
+                fillRule="nonzero"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+);

--- a/packages/ui-markdown-editor/src/components/icons/deleteRow.js
+++ b/packages/ui-markdown-editor/src/components/icons/deleteRow.js
@@ -1,0 +1,44 @@
+import React from "react";
+
+/**
+ * Renders the icon for deleting row in svg format.
+ *
+ * @returns {HTMLOrSVGElement} SVG for the Delete row icon
+ */
+
+export default () => (
+  <div>
+    <svg
+      width="20px"
+      height="20px"
+      viewBox="0 0 1024 1024"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        id="Old-pages"
+        stroke="none"
+        strokeWidth="1"
+        fill="none"
+        fillRule="evenodd"
+      >
+        <g id="Hyperlink-UI" transform="translate(-15.000000, -162.000000)">
+          <g id="Group-6" transform="translate(0.000000, 2.000000)">
+            <g
+              id="ic_content_copy_24px"
+              transform="translate(14.000000, 160.071068)"
+            >
+              <polygon id="Path" />
+              <path
+                d="M651.1 641.9c-1.4-1.2-3.2-1.9-5.1-1.9h-54.7c-2.4 0-4.6 1.1-6.1 2.9L512 730.7l-73.1-87.8c-1.5-1.8-3.8-2.9-6.1-2.9H378c-1.9 0-3.7 0.7-5.1 1.9-3.4 2.8-3.9 7.9-1 11.3L474.2 776 371.8 898.9c-2.8 3.4-2.4 8.4 1 11.3 1.4 1.2 3.2 1.9 5.1 1.9h54.7c2.4 0 4.6-1.1 6.1-2.9l73.1-87.8 73.1 87.8c1.5 1.8 3.8 2.9 6.1 2.9h55c1.9 0 3.7-0.7 5.1-1.9 3.4-2.8 3.9-7.9 1-11.3L549.8 776l102.4-122.9c2.8-3.4 2.3-8.4-1.1-11.2zM472 544h80c4.4 0 8-3.6 8-8V120c0-4.4-3.6-8-8-8h-80c-4.4 0-8 3.6-8 8v416c0 4.4 3.6 8 8 8zM350 386H184V136c0-3.3-2.7-6-6-6h-60c-3.3 0-6 2.7-6 6v292c0 16.6 13.4 30 30 30h208c3.3 0 6-2.7 6-6v-60c0-3.3-2.7-6-6-6zM906 130h-60c-3.3 0-6 2.7-6 6v250H674c-3.3 0-6 2.7-6 6v60c0 3.3 2.7 6 6 6h208c16.6 0 30-13.4 30-30V136c0-3.3-2.7-6-6-6z"
+                id="Shape"
+                fill="#959CA3"
+                fillRule="nonzero"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+);

--- a/packages/ui-markdown-editor/src/components/icons/deleteTable.js
+++ b/packages/ui-markdown-editor/src/components/icons/deleteTable.js
@@ -1,0 +1,44 @@
+import React from "react";
+
+/**
+ * Renders the icon for deleting table in svg format.
+ *
+ * @returns {HTMLOrSVGElement} SVG for the Delete Table icon
+ */
+
+export default () => (
+  <div>
+    <svg
+      width="20px"
+      height="20px"
+      viewBox="0 0 1024 1024"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        id="Old-pages"
+        stroke="none"
+        strokeWidth="1"
+        fill="none"
+        fillRule="evenodd"
+      >
+        <g id="Hyperlink-UI" transform="translate(-15.000000, -162.000000)">
+          <g id="Group-6" transform="translate(0.000000, 2.000000)">
+            <g
+              id="ic_content_copy_24px"
+              transform="translate(14.000000, 160.071068)"
+            >
+              <polygon id="Path" />
+              <path
+                d="M360 184h-8c4.4 0 8-3.6 8-8v8h304v-8c0 4.4 3.6 8 8 8h-8v72h72v-80c0-35.3-28.7-64-64-64H352c-35.3 0-64 28.7-64 64v80h72v-72zm504 72H160c-17.7 0-32 14.3-32 32v32c0 4.4 3.6 8 8 8h60.4l24.7 523c1.6 34.1 29.8 61 63.9 61h454c34.2 0 62.3-26.8 63.9-61l24.7-523H888c4.4 0 8-3.6 8-8v-32c0-17.7-14.3-32-32-32zM731.3 840H292.7l-24.2-512h487l-24.2 512z"
+                id="Shape"
+                fill="#959CA3"
+                fillRule="nonzero"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+);

--- a/packages/ui-markdown-editor/src/components/icons/index.js
+++ b/packages/ui-markdown-editor/src/components/icons/index.js
@@ -10,6 +10,7 @@ import undo from './undo';
 import redo from './redo';
 import tbreak from './tbreak';
 import Separator from './separator';
+import table from './table';
 
 export {
   bold,
@@ -23,5 +24,6 @@ export {
   undo,
   redo,
   tbreak,
-  Separator
+  Separator,
+  table
 };

--- a/packages/ui-markdown-editor/src/components/icons/row.js
+++ b/packages/ui-markdown-editor/src/components/icons/row.js
@@ -1,0 +1,44 @@
+import React from "react";
+
+/**
+ * Renders the icon for inserting row in svg format.
+ *
+ * @returns {HTMLOrSVGElement} SVG for the Insert row icon
+ */
+
+export default () => (
+  <div>
+    <svg
+      width="20px"
+      height="20px"
+      viewBox="0 0 1024 1024"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        id="Old-pages"
+        stroke="none"
+        strokeWidth="1"
+        fill="none"
+        fillRule="evenodd"
+      >
+        <g id="Hyperlink-UI" transform="translate(-15.000000, -162.000000)">
+          <g id="Group-6" transform="translate(0.000000, 2.000000)">
+            <g
+              id="ic_content_copy_24px"
+              transform="translate(14.000000, 160.071068)"
+            >
+              <polygon id="Path" />
+              <path
+                d="M904 768H120c-4.4 0-8 3.6-8 8v80c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-80c0-4.4-3.6-8-8-8zM878.7 160H145.3c-18.4 0-33.3 14.3-33.3 32v464c0 17.7 14.9 32 33.3 32h733.3c18.4 0 33.3-14.3 33.3-32V192c0.1-17.7-14.8-32-33.2-32zM360 616H184V456h176v160z m0-224H184V232h176v160z m240 224H424V456h176v160z m0-224H424V232h176v160z m240 224H664V456h176v160z m0-224H664V232h176v160z"
+                id="Shape"
+                fill="#959CA3"
+                fillRule="nonzero"
+              />
+            </g>
+          </g>
+        </g>
+      </g>
+    </svg>
+  </div>
+);

--- a/packages/ui-markdown-editor/src/components/icons/table.js
+++ b/packages/ui-markdown-editor/src/components/icons/table.js
@@ -1,0 +1,31 @@
+import React from "react";
+
+/**
+ * Renders the icon for Table in svg format.
+ *
+ * @returns {HTMLOrSVGElement} SVG for the Table icon
+ */
+const icon = () => (
+  <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+    <path
+      d="M0,37.215v55v15v300.57h445v-300.57v-15v-55H0z M276.667,277.595H168.333v-70.19h108.334V277.595z M306.667,207.405H415
+	v70.19H306.667V207.405z M276.667,307.595v70.19H168.333v-70.19H276.667z M30,207.405h108.333v70.19H30V207.405z M168.333,177.405
+	v-70.19h108.334v70.19H168.333z M138.333,107.215v70.19H30v-70.19H138.333z M30,307.595h108.333v70.19H30V307.595z M306.667,377.785
+	v-70.19H415v70.19H306.667z M415,177.405H306.667v-70.19H415V177.405z"
+      fill="#949CA2"
+      fillRule="nonzero"
+    />
+  </g>
+);
+
+const table = {
+  type: "table",
+  label: `Insert table`,
+  height: "25px",
+  width: "25px",
+  padding: "4px",
+  viewBox: "0 0 445 445",
+  icon,
+};
+
+export default table;

--- a/packages/ui-markdown-editor/src/components/index.js
+++ b/packages/ui-markdown-editor/src/components/index.js
@@ -7,7 +7,7 @@ import { HorizontalRule } from './Span';
 import {
   PARAGRAPH, LINK, IMAGE, H1, H2, H3, H4, H5, H6, HR,
   CODE_BLOCK, HTML_BLOCK, BLOCK_QUOTE, UL_LIST, OL_LIST, LIST_ITEM,
-  HTML_INLINE, SOFTBREAK, LINEBREAK, HEADINGS
+  HTML_INLINE, SOFTBREAK, LINEBREAK, HEADINGS, TABLE, TABLE_ROW, TABLE_CELL
 } from '../utilities/schema';
 import {
   H1_STYLING,
@@ -16,7 +16,9 @@ import {
   H4_STYLING,
   H5_STYLING,
   H6_STYLING,
-  PARAGRAPH_STYLING
+  PARAGRAPH_STYLING,
+  TABLE_CELL_STYLING,
+  TABLE_STYLING
 } from '../utilities/constants';
 import generateId from '../utilities/generateId';
 
@@ -59,6 +61,9 @@ const Element = (props) => {
     [HTML_INLINE]: () => (<span className={HTML_INLINE} {...attributes}>
       {data.content}{children}
     </span>),
+    [TABLE] : () => (<table style={TABLE_STYLING}> <tbody {...attributes}>{children}</tbody> </table>),
+    [TABLE_ROW] : () => (<tr {...attributes}>{children}</tr>),
+    [TABLE_CELL] : () => (<td {...attributes} style={TABLE_CELL_STYLING}>{children}</td>),
     default: () => {
       console.log(`Didn't know how to render ${JSON.stringify(element, null, 2)}`);
       return <p {...attributes}>{children}</p>;

--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -22,6 +22,7 @@ import { withHtml } from './plugins/withHtml';
 import { withLists } from './plugins/withLists';
 import FormatBar from './FormattingToolbar';
 import { withText } from './plugins/withText';
+import { withTables, isSelectionTable } from 'plugins/withTables';
 
 export const markdownToSlate = (markdown) => {
   const slateTransformer = new SlateTransformer();
@@ -37,18 +38,19 @@ export const MarkdownEditor = (props) => {
     canBeFormatted
   } = props;
   const [showLinkModal, setShowLinkModal] = useState(false);
+  const [showTableModal, setShowTableModal] = useState(false);
   const [currentStyle, setCurrentStyle] = useState('');
   const editor = useMemo(() => {
     if (augmentEditor) {
       return augmentEditor(
-        withLists(withLinks(withHtml(withImages(withText(
+        withTables(withLists(withLinks(withHtml(withImages(withText(
           withSchema(withHistory(withReact(createEditor())))
-        )))))
+        ))))))
       );
     }
-    return withLists(withLinks(withHtml(withImages(withText(
+    return withTables(withLists(withLinks(withHtml(withImages(withText(
       withSchema(withHistory(withReact(createEditor())))
-    )))));
+    ))))));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -190,6 +192,9 @@ export const MarkdownEditor = (props) => {
       if (selection && isSelectionLinkBody(editor)) {
         setShowLinkModal(true);
       }
+      if (selection && isSelectionTable(editor)) {
+        setShowTableModal(true);
+      }
       const currentStyleCalculated = BLOCK_STYLE[Node.parent(editor, editor.selection.focus.path).type] || 'Style';
       setCurrentStyle(currentStyleCalculated);
     } catch (err) {
@@ -243,6 +248,8 @@ export const MarkdownEditor = (props) => {
         canBeFormatted={props.canBeFormatted}
         showLinkModal={showLinkModal}
         setShowLinkModal={setShowLinkModal}
+        showTableModal={showTableModal}
+        setShowTableModal={setShowTableModal}
         activeButton={props.activeButton || BUTTON_ACTIVE}
         /> }
       <Editable

--- a/packages/ui-markdown-editor/src/plugins/withTables.js
+++ b/packages/ui-markdown-editor/src/plugins/withTables.js
@@ -1,0 +1,253 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Popup } from "semantic-ui-react";
+import { useEditor } from "slate-react";
+import { Editor, Transforms, Range, Element, Point } from "slate";
+
+import { POPUP_STYLE } from "../utilities/constants";
+import Button from "../components/Button";
+
+/**
+ * Checks if the selection is a table or not.
+ *
+ * @param {Object} editor Editor in which the table is to be checked
+ * @returns {boolean} Selection in editor is table or not
+ */
+export const isSelectionTable = (editor) => {
+  const [tableNode] = Editor.nodes(editor, {
+    match: (n) =>
+      !Editor.isEditor(n) && Element.isElement(n) && n.type === "table",
+  });
+
+  return !!tableNode;
+};
+
+/**
+ * Extends the editor's features by including the table feature.
+ *
+ * @param {Object} editor Editor to be improved
+ * @returns {Object} Editor with the table functionality
+ */
+
+export const withTables = (editor) => {
+  const { deleteBackward, deleteForward, insertBreak } = editor;
+
+  editor.deleteBackward = (unit) => {
+    const { selection } = editor;
+    if (selection) {
+      const [cell] = Editor.nodes(editor, {
+        match: (n) =>
+          !Editor.isEditor(n) &&
+          Element.isElement(n) &&
+          n.type === "table-cell",
+      });
+      const prevNodePath = Editor.before(editor, selection);
+
+      const [tableNode] = Editor.nodes(editor, {
+        at: prevNodePath,
+        match: (n) =>
+          !Editor.isEditor(n) && Element.isElement && n.type === "table-cell",
+      });
+
+      if (cell) {
+        const [, cellPath] = cell;
+
+        const start = Editor.start(editor, cellPath);
+        if (Point.equals(selection.anchor, start)) {
+          return;
+        }
+      }
+      if (!cell && tableNode) {
+        return;
+      }
+    }
+
+    deleteBackward(unit);
+  };
+  editor.deleteForward = (unit) => {
+    const { selection } = editor;
+    if (selection && Range.isCollapsed(selection)) {
+      const [cell] = Editor.nodes(editor, {
+        match: (n) =>
+          !Editor.isEditor(n) &&
+          Element.isElement(n) &&
+          n.type === "table-cell",
+      });
+
+      const prevNodePath = Editor.after(editor, selection);
+      const [tableNode] = Editor.nodes(editor, {
+        at: prevNodePath,
+        match: (n) =>
+          !Editor.isEditor(n) && Element.isElement && n.type === "table-cell",
+      });
+
+      if (cell) {
+        const [, cellPath] = cell;
+        const end = Editor.end(editor, cellPath);
+
+        if (Point.equals(selection.anchor, end)) {
+          return;
+        }
+      }
+      if (!cell && tableNode) {
+        return;
+      }
+    }
+
+    deleteForward(unit);
+  };
+
+  editor.insertBreak = () => {
+    const { selection } = editor;
+    if (selection) {
+      const [table] = Editor.nodes(editor, {
+        match: (n) =>
+          !Editor.isEditor(n) && Element.isElement(n) && n.type === "table",
+      });
+
+      if (table) {
+        return;
+      }
+    }
+
+    insertBreak();
+  };
+  return editor;
+};
+
+/**
+ * Inserts and Deletes rows and columns into the editor
+ *
+ * @param {Object} editor    Editor which has to be improved
+ * @param {Node}   tableNode table which has to be edited
+ * @param {string} action    action to be performed
+ * @param {Path}   path      the path of the table
+ */
+export const handleCells = (tableNode, path, action, editor) => {
+  let existingText = Array.from(tableNode.children, (rows) =>
+    Array.from(rows.children, (arr) => arr.children[0].text)
+  );
+  const columns = existingText[0].length;
+  if (action === "row") {
+    existingText.push(Array(columns).fill(""));
+  } else if (action === "col") {
+    existingText = Array.from(existingText, (item) => {
+      item.push("");
+      return item;
+    });
+  } else if (action === "drow") {
+    existingText.pop();
+  } else {
+    existingText = Array.from(existingText, (item) => {
+      item.pop("");
+      return item;
+    });
+  }
+  const newTable = createTableNode(existingText);
+  Transforms.insertNodes(editor, newTable, {
+    at: path,
+  });
+};
+
+const createTableCell = (text) => {
+  return {
+    type: "table-cell",
+    children: [{ text }],
+  };
+};
+
+const createRow = (cellText) => {
+  const newRow = Array.from(cellText, (value) => createTableCell(value));
+  return {
+    type: "table-row",
+    children: newRow,
+  };
+};
+
+const createTableNode = (cellText) => {
+  const tableChildren = Array.from(cellText, (value) => createRow(value));
+  let tableNode = { type: "table", children: tableChildren };
+  return tableNode;
+};
+
+/**
+ * Inserts a table into the editor
+ *
+ * @param {Object} editor  Editor in which image is to be inserted
+ * @param {number} rows    rows of the table.
+ * @param {number} columns columns of the table.
+ */
+export const insertTable = (editor, rows, columns) => {
+  const [tableNode] = Editor.nodes(editor, {
+    match: (n) =>
+      !Editor.isEditor(n) && Element.isElement(n) && n.type === "table",
+    mode: "highest",
+  });
+
+  if (tableNode) return;
+  if (!rows || !columns) {
+    return;
+  }
+  const cellText = Array.from({ length: rows }, () =>
+    Array.from({ length: columns }, () => "")
+  );
+  const newTable = createTableNode(cellText);
+
+  Transforms.insertNodes(editor, newTable, {
+    mode: "highest",
+  });
+  Transforms.insertNodes(
+    editor,
+    { type: "paragraph", children: [{ text: "" }] },
+    { mode: "highest" }
+  );
+};
+
+export const InsertTableButton = ({
+  showTableModal,
+  setShowTableModal,
+  type,
+  label,
+  icon,
+  canBeFormatted,
+  ...props
+}) => {
+  const isActive = showTableModal;
+  const editor = useEditor();
+
+  /**
+   * Shows the modal on mouse click if the document is in editable mode.
+   */
+  const handleMouseDown = () => {
+    if (!canBeFormatted(editor)) return;
+    if (editor.selection) setShowTableModal(true);
+  };
+  return (
+    <Popup
+      content={label}
+      style={POPUP_STYLE}
+      position="bottom center"
+      trigger={
+        <Button
+          aria-label={type}
+          onMouseDown={handleMouseDown}
+          isActive={isActive}
+          {...props}
+        >
+          {icon()}
+        </Button>
+      }
+    />
+  );
+};
+
+InsertTableButton.displayName = "InsertTableButton";
+
+InsertTableButton.propTypes = {
+  showTableModal: PropTypes.bool,
+  setShowTableModal: PropTypes.func,
+  icon: PropTypes.func,
+  type: PropTypes.string,
+  label: PropTypes.string,
+  canBeFormatted: PropTypes.func,
+};

--- a/packages/ui-markdown-editor/src/utilities/constants.js
+++ b/packages/ui-markdown-editor/src/utilities/constants.js
@@ -92,6 +92,17 @@ export const H6_STYLING = {
   fontWeight: MISC_CONSTANTS.DROPDOWN_WEIGHT,
 };
 
+export const TABLE_CELL_STYLING = {
+  border: "1px solid black",
+  height: "50px",
+  padding: "0 5px",
+};
+
+export const TABLE_STYLING = {
+  width: "100%",
+  borderCollapse: "collapse",
+};
+
 export const TOOLBAR_DROPDOWN_STYLE_H1 = {
   ...H1_STYLING,
   margin: 0

--- a/packages/ui-markdown-editor/src/utilities/schema.js
+++ b/packages/ui-markdown-editor/src/utilities/schema.js
@@ -30,6 +30,10 @@ export const IMAGE = 'image';
 export const HTML_INLINE = 'html_inline';
 export const HEADINGBREAK = 'headingbreak';
 
+export const TABLE = "table";
+export const TABLE_ROW = "table-row";
+export const TABLE_CELL = "table-cell";
+
 const INLINES = {
   [LINEBREAK]: true,
   [SOFTBREAK]: true,


### PR DESCRIPTION
Signed-off-by: TC5022 <tanyac5022002@gmail.com>

# Closes #39 
Extended the current markdown-editor UI to support, render and edit tables.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Added various SVG icons which are consistent with the icons currently present.
- <TWO> Added a table modal that allows the user to perform various functions like adding and deleting rows and columns
- <THREE> Added support to render tables and navigate them using keyboard arrows


### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->


https://user-images.githubusercontent.com/75262300/153654435-1665a686-84b7-4adf-a102-475906654d62.mp4


### Author Checklist
- [ ] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [ ] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [ ] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions
