### PR TITLE
fix(storybook): Possible to split paragraphs in half with drag and drop

### DIFF
--- a/packages/ui-markdown-editor/src/index.js
+++ b/packages/ui-markdown-editor/src/index.js
@@ -252,28 +252,32 @@ export const MarkdownEditor = (props) => {
         setShowTableModal={setShowTableModal}
         activeButton={props.activeButton || BUTTON_ACTIVE}
         /> }
-      <Editable
-        id="ap-rich-text-editor"
-        style={{
+      <div id='ap-rich-text-editor-parent'
+       style={{
           padding: '0px 20px 10px 20px',
           border: '1px solid grey',
           borderRadius: '4px',
-          minWidth: '600px'
-        }}
-        readOnly={props.readOnly}
-        renderElement={renderElement}
-        renderLeaf={renderLeaf}
-        placeholder={props.placeholder || 'Enter some text here...'}
-        spellCheck
-        autoFocus
-        onKeyDown={onKeyDown}
-        onDOMBeforeInput={onBeforeInput}
-        onCopy={handleCopyOrCut}
-        onCut={event => handleCopyOrCut(event, true)}
-        onDragStart={handleDragStart}
-        onDragOver={event => props.onDragOver ? props.onDragOver(editor, event) : null}
-        onDrop={handleDrop}
-      />
+       }}>
+        <Editable
+         id="ap-rich-text-editor"
+         style={{
+           minWidth: '600px'
+         }}
+         readOnly={props.readOnly}
+         renderElement={renderElement}
+         renderLeaf={renderLeaf}
+         placeholder={props.placeholder || 'Enter some text here...'}
+         spellCheck
+         autoFocus
+         onKeyDown={onKeyDown}
+         onDOMBeforeInput={onBeforeInput}
+         onCopy={handleCopyOrCut}
+         onCut={event => handleCopyOrCut(event, true)}
+         onDragStart={handleDragStart}
+         onDragOver={event => props.onDragOver ? props.onDragOver(editor, event) : null}
+         onDrop={handleDrop}
+        />
+      </div>
     </Slate>
   );
 };


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #120 
The fix was simple. The main issue was due to padding of ap-rich-text-editor. I think @irmerk already mentioned it .I just created a parent div added the padding and border of ap-rich-text-editor to it and it fixed the issue.

###  Video Links of:
observed Behavior: [link](https://www.loom.com/share/6bd037d8267f466d833fa9e91913b6a9?sid=1912f6c3-9c8b-41bf-9b22-d370ab260074)
Fixed behavior:[Link](https://www.loom.com/share/6bb61ed53f084d6c993066e49a3a4222?sid=7aee13d5-f0ca-42e4-8626-93e87598836d)
 
