### PR TITLE
feat(ui-concerto-editor): add graphical editor for Concerto data models

### DIFF
--- a/packages/ui-concerto-editor/README.md
+++ b/packages/ui-concerto-editor/README.md
@@ -1,0 +1,90 @@
+# @accordproject/ui-concerto-editor
+
+A visual editor for [Concerto](https://concerto.accordproject.org/) data models — my proof of concept for **GSoC 2026, Project 2: Concerto Graphical Editor**.
+
+This is a new package in the [web-components](https://github.com/accordproject/web-components) monorepo, built on top of [PR #436](https://github.com/accordproject/web-components/pull/436). 
+
+Right now, building Concerto models means writing ".cto" code by hand. This tool lets you do it visually instead — you see your model as a graph of connected nodes, and you can edit it by clicking, dragging, and filling in dialogs. The CTO code updates automatically.
+
+## What it does
+
+**The basics:**
+- You get a split view: CTO text on the left, interactive graph on the right
+- Edit either side and the other stays in sync
+- Nodes represent concepts, enums, and maps. Edges show how they relate
+
+**Editing from the graph (no code needed):**
+- Add new concepts, enums, assets, participants, events, transactions, maps
+- Add/remove properties on any concept
+- Set property type, optional, array, or relationship ("-->")
+- Toggle abstract on/off
+- Set inheritance ("extends") via dialog or by dragging between nodes
+- Add/remove enum values
+- Delete any declaration
+
+**Other stuff:**
+- Undo/redo that also remembers where you dragged nodes (Ctrl+Z / Ctrl+Shift+Z)
+- Import/export ".cto" files
+- Syntax highlighting in the text editor with colors matching the graph
+- Collapsible text panel (hide it to get full-screen graph)
+- Dendrogram layout that auto-arranges nodes in a tree
+
+## How it looks
+
+The graph uses different visual styles to help you read the model at a glance:
+
+- **Blue nodes** — concepts (darker blue for assets, purple for participants, etc.)
+- **Yellow/gold nodes** — enums
+- **Teal nodes** — maps
+- **Solid blue lines** — property (this concept *contains* that type)
+- **Dashed red lines** — relationship (this concept *references* that type)
+- **Animated purple lines** — inheritance (extends)
+
+## Concerto features covered
+
+Based on the [Concerto specification](https://concerto.accordproject.org/docs/category/specification) and the [GSoC project description](https://github.com/accordproject/techdocs/wiki/Google-Summer-of-Code-2026-Ideas-List):
+
+- Type composition (concept with properties of other concept types)
+- Enumerations (full create/edit/delete)
+- Inheritance ("extends")
+- Abstract types (toggle)
+- Relationships ("-->")
+- Arrays ("Type[]")
+- Maps ("map Name { o KeyType o ValueType }")
+- Namespace (parsed and preserved)
+
+## Built with
+
+- **React 18** + **TypeScript**
+- **React Flow** ("@xyflow/react" v12) for the graph
+- **Vite** for dev/build
+- **@accordproject/concerto-core** as a dependency (for future integration with the real parser)
+
+Currently using a custom regex-based CTO parser. One of the next steps is replacing it with "concerto-core"'s actual parser.
+
+## Project structure
+
+The code is split into two main folders: "components/" for the React UI and "utils/" for the data logic.
+
+**Components:**
+- **ConcertoGraphEditor** — the main component that wires everything together: React Flow canvas, state management, bidirectional sync, undo/redo, and all the edit operations
+- **ConceptNode / EnumNode / MapNode** — custom React Flow nodes for each Concerto declaration type, with inline edit buttons
+- **Toolbar** — the top bar with add/import/export/undo/redo buttons, plus all the popup dialogs for adding declarations, properties, enum values, and setting inheritance
+- **CtoEditor** — the syntax-highlighted text editor (transparent textarea layered over a colored "pre" element)
+
+**Utils:**
+- **types.ts** — shared TypeScript interfaces (Declaration, Property, ConcertoModel, etc.)
+- **ctoToGraph.ts** — parses a CTO string into a model, computes the tree layout, and generates React Flow nodes and edges
+- **graphToCto.ts** — the reverse: takes the model and generates valid CTO code
+- **defaultModel.ts** — a demo NDA model used on first load
+
+## Running it
+
+```bash
+cd packages/ui-concerto-editor
+npm install
+npm run dev
+```
+
+- Portfolio: [soniaduma.dev](https://soniaduma.dev)
+- LinkedIn: [linkedin.com/in/sonia-duma-555786283](https://www.linkedin.com/in/sonia-duma-555786283)

--- a/packages/ui-concerto-editor/index.html
+++ b/packages/ui-concerto-editor/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <title>Concerto Graphical Editor</title>
+    <style>
+      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+      code, pre, .monospace, textarea { font-family: 'JetBrains Mono', 'Fira Code', monospace; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/ui-concerto-editor/package-lock.json
+++ b/packages/ui-concerto-editor/package-lock.json
@@ -1,0 +1,4234 @@
+{
+  "name": "@accordproject/ui-concerto-editor",
+  "version": "0.98.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@accordproject/ui-concerto-editor",
+      "version": "0.98.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "^4.1.0",
+        "@accordproject/concerto-cto": "^4.1.0",
+        "@xyflow/react": "^12.10.2"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.7.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "typescript": "^5.9.3",
+        "vite": "^5.4.21",
+        "vite-plugin-node-polyfills": "^0.26.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@accordproject/concerto-core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.0.tgz",
+      "integrity": "sha512-xeTygQ4pWx9unxSS/suM+HXfcOGvMx1gTVKBZYcZu4XX/024x/yU0tivDFrIhMewU+Q5K61sCq5eGenW1cQnKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "4.1.0",
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.0",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-cto": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.0.tgz",
+      "integrity": "sha512-6e0O20lzG1tT+4kHLljhVQXfHVJUI882htSGcQFLhuvhhqLXnBAMaLsPBI0oVHGmnjsmBqrWp7hIfjCZSTdsEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.0",
+        "acorn": "^8.15.0",
+        "path-browserify": "^1.0.1",
+        "schema-utils": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-metamodel": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.0.tgz",
+      "integrity": "sha512-BkWJLYvWkDAG1lPgEr0T/4IqhjqEqzMVxAfFdJzDH3lxfEJsZ+bVJZzdcsHZUubuO0SsoahuHSs4j2Cv7DQ+Lw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@accordproject/concerto-util": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.0.tgz",
+      "integrity": "sha512-XclLitB+wVd/gq2RXmiG/HYCGGOzk8tnuW02QjSb3w1P/oUrNYXz1+YxkGL2mVwD5oZ2pPzHDfQdiP5GCWWigA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-util/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/concerto-util/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-inject": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@supercharge/promise-pool": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-1.7.0.tgz",
+      "integrity": "sha512-OpnF7oqk6asrOUMhldnDju4RKeZ/iMAfw3LIoLdcTI53RZJLiQ9vEAcGW+bcBELXkiPhT7RqtuPSXAFF2iAmbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browser-resolve": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.17.0"
+      }
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
+      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.2",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+      "dev": true
+    },
+    "node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/domain-browser": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
+      "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isomorphic-timers-promises": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
+      "integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lorem-ipsum": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.8.tgz",
+      "integrity": "sha512-5RIwHuCb979RASgCJH0VKERn9cQo/+NcAi2BMe9ddj+gp7hujl6BI+qdOG4nVsLDpwWEJwTVYXNKP6BGgbcoGA==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^9.3.0"
+      },
+      "bin": {
+        "lorem-ipsum": "dist/bin/lorem-ipsum.bin.js"
+      },
+      "engines": {
+        "node": ">= 8.x",
+        "npm": ">= 5.x"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-stdlib-browser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.1.tgz",
+      "integrity": "sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assert": "^2.0.0",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^5.7.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "create-require": "^1.1.1",
+        "crypto-browserify": "^3.12.1",
+        "domain-browser": "4.22.0",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "isomorphic-timers-promises": "^1.0.1",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.1",
+        "pkg-dir": "^5.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.4.1",
+        "querystring-es3": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.1",
+        "url": "^0.11.4",
+        "util": "^0.12.4",
+        "vm-browserify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
+      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "license": "MIT",
+      "dependencies": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripemd160/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ripemd160/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ripemd160/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/timers-browserify": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-node-polyfills": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.26.0.tgz",
+      "integrity": "sha512-BAe5YzJf368XGev02hDvioidx4uVH8dqEJlG73bjQSxM26/AQnGcKFomq9n3vGq5yqpSHKN4h1XQNxx9l98mBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/plugin-inject": "^5.0.5",
+        "node-stdlib-browser": "^1.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/davidmyersdev"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/packages/ui-concerto-editor/package.json
+++ b/packages/ui-concerto-editor/package.json
@@ -16,23 +16,23 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@accordproject/concerto-core": "^3.25.7",
-    "@accordproject/concerto-cto": "^3.25.7",
-    "@xyflow/react": "^12.0.0"
+    "@accordproject/concerto-core": "^4.1.0",
+    "@accordproject/concerto-cto": "^4.1.0",
+    "@xyflow/react": "^12.10.2"
   },
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0",
-    "@vitejs/plugin-react": "^4.2.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "^5.0.0",
-    "vite": "^5.0.0",
-    "vite-plugin-node-polyfills": "^0.22.0"
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "typescript": "^5.9.3",
+    "vite": "^5.4.21",
+    "vite-plugin-node-polyfills": "^0.26.0"
   },
   "repository": {
     "type": "git",

--- a/packages/ui-concerto-editor/package.json
+++ b/packages/ui-concerto-editor/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@accordproject/ui-concerto-editor",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Graphical editor for Concerto data models using React Flow",
+  "main": "lib/index.cjs.js",
+  "module": "lib/index.esm.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "test": "jest --passWithNoTests",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@accordproject/concerto-core": "^3.25.7",
+    "@accordproject/concerto-cto": "^3.25.7",
+    "@xyflow/react": "^12.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vite-plugin-node-polyfills": "^0.22.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/accordproject/web-components",
+    "directory": "packages/ui-concerto-editor"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/ui-concerto-editor/package.json
+++ b/packages/ui-concerto-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@accordproject/ui-concerto-editor",
-  "version": "0.1.0",
+  "version": "0.98.0",
   "private": false,
   "description": "Graphical editor for Concerto data models using React Flow",
   "main": "lib/index.cjs.js",

--- a/packages/ui-concerto-editor/src/App.tsx
+++ b/packages/ui-concerto-editor/src/App.tsx
@@ -1,0 +1,63 @@
+import { useState, useCallback, useMemo } from 'react';
+import { ConcertoGraphEditor } from './components/ConcertoGraphEditor';
+import { CtoEditor } from './components/CtoEditor';
+import { defaultCto } from './utils/defaultModel';
+import { validateCto } from './utils/ctoToGraph';
+
+export default function App() {
+  const [cto, setCto] = useState(defaultCto);
+  const [showText, setShowText] = useState(true);
+  const validationError = useMemo(() => validateCto(cto), [cto]);
+
+  const handleModelChange = useCallback((newCto: string) => {
+    setCto(newCto);
+  }, []);
+
+  const handleImport = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.cto';
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => setCto(reader.result as string);
+      reader.readAsText(file);
+    };
+    input.click();
+  };
+
+  const handleExport = () => {
+    const blob = new Blob([cto], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'model.cto';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden', flexDirection: 'column' }}>
+      {/* Content */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        {showText && (
+          <div style={{ width: '35%', display: 'flex', flexDirection: 'column', borderRight: '1px solid #4a5568' }}>
+            <CtoEditor value={cto} onChange={setCto} error={validationError} />
+          </div>
+        )}
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+          <ConcertoGraphEditor
+            cto={cto}
+            onModelChange={handleModelChange}
+            showText={showText}
+            onToggleText={() => setShowText(!showText)}
+            onImport={handleImport}
+            onExport={handleExport}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/packages/ui-concerto-editor/src/components/ConceptNode.tsx
+++ b/packages/ui-concerto-editor/src/components/ConceptNode.tsx
@@ -1,0 +1,182 @@
+import { Handle, Position } from '@xyflow/react';
+import type { Declaration } from '../utils/types';
+
+const TYPE_COLORS: Record<string, string> = {
+  String: '#68d391',
+  Integer: '#63b3ed',
+  Long: '#63b3ed',
+  Double: '#63b3ed',
+  Boolean: '#fbd38d',
+  DateTime: '#d6bcfa',
+};
+
+const DECL_COLORS: Record<string, { bg: string; accent: string }> = {
+  concept: { bg: '#2b4acb', accent: '#5a7af5' },
+  asset: { bg: '#276749', accent: '#48bb78' },
+  participant: { bg: '#6b46c1', accent: '#9f7aea' },
+  event: { bg: '#c53030', accent: '#fc8181' },
+  transaction: { bg: '#c05621', accent: '#ed8936' },
+};
+
+interface ConceptNodeData {
+  label: string;
+  declaration: Declaration;
+  onAddProperty?: (declName: string) => void;
+  onDeleteProperty?: (declName: string, propName: string) => void;
+  onDeleteDeclaration?: (declName: string) => void;
+  onToggleAbstract?: (declName: string) => void;
+  onSetInheritance?: (declName: string) => void;
+}
+
+export function ConceptNode({ data, selected }: { data: ConceptNodeData; selected?: boolean }) {
+  const { declaration } = data;
+  const colors = DECL_COLORS[declaration.type] || DECL_COLORS.concept;
+
+  return (
+    <div style={{
+      background: '#1e2533',
+      borderRadius: 12,
+      border: `2px solid ${selected ? '#fff' : colors.accent + '66'}`,
+      minWidth: 250,
+      boxShadow: selected
+        ? `0 0 20px ${colors.accent}44, 0 8px 24px rgba(0,0,0,0.4)`
+        : '0 4px 16px rgba(0,0,0,0.3)',
+      overflow: 'hidden',
+      transition: 'border-color 0.2s, box-shadow 0.2s',
+    }}>
+      <Handle type="target" position={Position.Top} id="top" style={{ ...handleStyle, background: colors.accent }} />
+      <Handle type="target" position={Position.Left} id="left" style={{ ...handleStyle, background: colors.accent }} />
+      <Handle type="source" position={Position.Right} id="right" style={{ ...handleStyle, background: colors.accent }} />
+
+      {/* Header */}
+      <div style={{
+        padding: '12px 14px 10px',
+        background: `linear-gradient(135deg, ${colors.bg}, ${colors.bg}cc)`,
+        borderBottom: `1px solid ${colors.accent}33`,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{
+              fontSize: 9, letterSpacing: 1.5, textTransform: 'uppercase',
+              color: colors.accent, fontWeight: 700,
+            }}>
+              {declaration.type}
+            </span>
+            {declaration.isAbstract && (
+              <span style={{
+                fontSize: 8, background: 'rgba(255,255,255,0.15)', color: '#fff',
+                padding: '2px 6px', borderRadius: 10, textTransform: 'uppercase',
+                letterSpacing: 0.5, cursor: 'pointer',
+              }} onClick={() => data.onToggleAbstract?.(declaration.name)} title="Toggle abstract">
+                abstract
+              </span>
+            )}
+            {!declaration.isAbstract && (
+              <span style={{
+                fontSize: 8, background: 'transparent', color: '#ffffff44',
+                padding: '2px 6px', borderRadius: 10, border: '1px solid #ffffff22',
+                textTransform: 'uppercase', letterSpacing: 0.5, cursor: 'pointer',
+              }} onClick={() => data.onToggleAbstract?.(declaration.name)} title="Make abstract">
+                concrete
+              </span>
+            )}
+          </div>
+          <button onClick={() => data.onDeleteDeclaration?.(declaration.name)}
+            style={{ background: 'none', border: 'none', color: '#ffffff55', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}
+            title="Delete"
+          >
+            &times;
+          </button>
+        </div>
+        {/* Decorators */}
+        {declaration.decorators?.length > 0 && (
+          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 2 }}>
+            {declaration.decorators.map((d) => (
+              <span key={d.name} style={{
+                fontSize: 8, color: '#fbb6ce', background: '#ed64a622', padding: '1px 5px',
+                borderRadius: 4, fontFamily: 'monospace',
+              }}>
+                @{d.name}{d.args.length > 0 ? `(${d.args.join(', ')})` : ''}
+              </span>
+            ))}
+          </div>
+        )}
+        <div style={{ fontSize: 15, fontWeight: 700, color: '#fff', marginTop: 4 }}>
+          {declaration.name}
+        </div>
+        {/* Identified */}
+        {declaration.identified === 'identified-by' && declaration.identifiedBy && (
+          <div style={{ fontSize: 10, color: '#68d391', marginTop: 2 }}>
+            identified by {declaration.identifiedBy}
+          </div>
+        )}
+        {declaration.identified === 'identified' && (
+          <div style={{ fontSize: 10, color: '#68d391', marginTop: 2 }}>
+            identified
+          </div>
+        )}
+        {declaration.superType && (
+          <div style={{ fontSize: 11, color: '#d6bcfa', marginTop: 4 }}>
+            extends {declaration.superType}
+          </div>
+        )}
+      </div>
+
+      {/* Properties */}
+      <div style={{ padding: '6px 6px 8px' }}>
+        {declaration.properties.map((prop) => (
+          <div key={prop.name} style={{
+            display: 'flex', alignItems: 'center', padding: '5px 8px', margin: '2px 0',
+            background: '#161b27', borderRadius: 6, gap: 8, fontSize: 12,
+          }}>
+            {prop.isRelationship && (
+              <span style={{ color: '#fc8181', fontSize: 10, fontWeight: 700 }}>&#8594;</span>
+            )}
+            <span style={{
+              color: TYPE_COLORS[prop.type] || colors.accent,
+              fontFamily: "'JetBrains Mono', monospace", fontSize: 11, fontWeight: 600, flexShrink: 0,
+            }}>
+              {prop.type}{prop.isArray ? '[]' : ''}
+            </span>
+            <span style={{ color: '#e2e8f0', flex: 1 }}>{prop.name}</span>
+            {prop.validators?.default && (
+              <span style={{ color: '#a0aec0', fontSize: 8, fontFamily: 'monospace' }}>={prop.validators.default}</span>
+            )}
+            {prop.validators?.regex && (
+              <span style={{ color: '#a0aec0', fontSize: 8, fontFamily: 'monospace' }}>{prop.validators.regex}</span>
+            )}
+            {prop.isOptional && (
+              <span style={{ color: '#fbd38d', fontSize: 9, fontWeight: 700, background: '#fbd38d22', padding: '1px 5px', borderRadius: 4 }}>
+                opt
+              </span>
+            )}
+            <button onClick={() => data.onDeleteProperty?.(declaration.name, prop.name)}
+              style={{ background: 'none', border: 'none', color: '#ffffff22', cursor: 'pointer', fontSize: 13, padding: 0, lineHeight: 1 }}
+              title="Delete property"
+            >
+              &times;
+            </button>
+          </div>
+        ))}
+        {declaration.properties.length === 0 && (
+          <div style={{ fontSize: 11, color: '#ffffff33', padding: '8px', textAlign: 'center', fontStyle: 'italic' }}>
+            No properties yet
+          </div>
+        )}
+        <button onClick={() => data.onAddProperty?.(declaration.name)} style={{
+          background: 'transparent', border: `1px dashed ${colors.accent}44`,
+          color: colors.accent + 'aa', cursor: 'pointer', fontSize: 11, fontWeight: 600,
+          padding: '5px 0', marginTop: 4, borderRadius: 6, width: '100%', textAlign: 'center',
+        }}>
+          + Add Property
+        </button>
+      </div>
+
+      <Handle type="source" position={Position.Bottom} id="bottom" style={{ ...handleStyle, background: colors.accent }} />
+    </div>
+  );
+}
+
+const handleStyle: React.CSSProperties = {
+  width: 10, height: 10, borderRadius: '50%', border: '2px solid #1e2533',
+};

--- a/packages/ui-concerto-editor/src/components/ConcertoGraphEditor.tsx
+++ b/packages/ui-concerto-editor/src/components/ConcertoGraphEditor.tsx
@@ -52,8 +52,8 @@ interface HistoryEntry {
 const MAX_HISTORY = 50;
 
 export function ConcertoGraphEditor({ cto, onModelChange, showText, onToggleText, onImport, onExport }: ConcertoGraphEditorProps) {
-  const [nodes, setNodes, onNodesChange] = useNodesState([]);
-  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const [model, setModelState] = useState<ConcertoModel>({ namespace: 'org.example@1.0.0', imports: [], declarations: [] });
   const modelRef = useRef(model);
   const setModel = useCallback((m: ConcertoModel) => { modelRef.current = m; setModelState(m); }, []);

--- a/packages/ui-concerto-editor/src/components/ConcertoGraphEditor.tsx
+++ b/packages/ui-concerto-editor/src/components/ConcertoGraphEditor.tsx
@@ -1,0 +1,442 @@
+import { useCallback, useEffect, useState, useRef } from 'react';
+import {
+  ReactFlow,
+  Background,
+  useNodesState,
+  useEdgesState,
+  BackgroundVariant,
+  type NodeTypes,
+  type EdgeTypes,
+  type Connection,
+  type Node,
+  type Edge,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+
+import { ConceptNode } from './ConceptNode';
+import { EnumNode } from './EnumNode';
+import { MapNode } from './MapNode';
+import { ScalarNode } from './ScalarNode';
+import { FloatingEdge } from './FloatingEdge';
+import { Toolbar } from './Toolbar';
+import { parseCto, declarationsToGraph } from '../utils/ctoToGraph';
+import { declarationsToCto } from '../utils/graphToCto';
+import type { Declaration, ConcertoModel } from '../utils/types';
+
+const nodeTypes: NodeTypes = {
+  conceptNode: ConceptNode,
+  enumNode: EnumNode,
+  mapNode: MapNode,
+  scalarNode: ScalarNode,
+};
+
+const edgeTypes: EdgeTypes = {
+  floating: FloatingEdge,
+};
+
+interface ConcertoGraphEditorProps {
+  cto: string;
+  onModelChange?: (cto: string) => void;
+  showText: boolean;
+  onToggleText: () => void;
+  onImport: () => void;
+  onExport: () => void;
+}
+
+interface HistoryEntry {
+  model: ConcertoModel;
+  nodes: Node[];
+  edges: Edge[];
+}
+
+const MAX_HISTORY = 50;
+
+export function ConcertoGraphEditor({ cto, onModelChange, showText, onToggleText, onImport, onExport }: ConcertoGraphEditorProps) {
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [model, setModelState] = useState<ConcertoModel>({ namespace: 'org.example@1.0.0', imports: [], declarations: [] });
+  const modelRef = useRef(model);
+  const setModel = useCallback((m: ConcertoModel) => { modelRef.current = m; setModelState(m); }, []);
+  const [activeDialog, setActiveDialog] = useState<{ type: 'property' | 'enum-value' | 'inheritance'; declName: string } | null>(null);
+  const [connectDialog, setConnectDialog] = useState<{ sourceId: string; targetId: string } | null>(null);
+  const updatingFromGraph = useRef(false);
+
+  // Undo/Redo history
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+  const isUndoRedo = useRef(false);
+
+  // Store current node positions so we can preserve them
+  const nodePositionsRef = useRef<Map<string, { x: number; y: number }>>(new Map());
+
+  // Keep positions ref in sync when nodes move (drag)
+  useEffect(() => {
+    for (const node of nodes) {
+      nodePositionsRef.current.set(node.id, { ...node.position });
+    }
+  }, [nodes]);
+
+  const pushHistory = useCallback((entry: HistoryEntry) => {
+    setHistory((prev) => {
+      const truncated = prev.slice(0, historyIndex + 1);
+      const next = [...truncated, entry];
+      if (next.length > MAX_HISTORY) next.shift();
+      return next;
+    });
+    setHistoryIndex((prev) => Math.min(prev + 1, MAX_HISTORY - 1));
+  }, [historyIndex]);
+
+  // CTO → Graph
+  useEffect(() => {
+    if (updatingFromGraph.current) {
+      updatingFromGraph.current = false;
+      return;
+    }
+    try {
+      const parsed = parseCto(cto);
+      setModel(parsed);
+      const graph = declarationsToGraph(parsed.declarations);
+      // Preserve existing positions for nodes that already exist
+      const nodesWithPositions = graph.nodes.map((node) => {
+        const savedPos = nodePositionsRef.current.get(node.id);
+        return savedPos ? { ...node, position: savedPos } : node;
+      });
+      setNodes(nodesWithPositions);
+      setEdges(graph.edges);
+      if (!isUndoRedo.current) {
+        pushHistory({ model: parsed, nodes: nodesWithPositions, edges: graph.edges });
+      }
+      isUndoRedo.current = false;
+    } catch {
+      // Ignore parse errors while user is typing — keep last valid graph state
+    }
+  }, [cto, setNodes, setEdges]);
+
+  // Graph → CTO (preserves node positions)
+  const updateModelAndSync = useCallback((newDeclarations: Declaration[]) => {
+    const cur = modelRef.current;
+    const newModel = { ...cur, declarations: newDeclarations };
+    const newCto = declarationsToCto(newModel);
+    setModel(newModel);
+    const graph = declarationsToGraph(newDeclarations);
+    const nodesWithPositions = graph.nodes.map((node) => {
+      const savedPos = nodePositionsRef.current.get(node.id);
+      return savedPos ? { ...node, position: savedPos } : node;
+    });
+    setNodes(nodesWithPositions);
+    setEdges(graph.edges);
+    pushHistory({ model: newModel, nodes: nodesWithPositions, edges: graph.edges });
+    updatingFromGraph.current = true;
+    onModelChange?.(newCto);
+  }, [setModel, setNodes, setEdges, onModelChange, pushHistory]);
+
+  // --- Operations ---
+
+  const handleAddDeclaration = useCallback((decl: Declaration) => {
+    updateModelAndSync([...modelRef.current.declarations, decl]);
+  }, [updateModelAndSync]);
+
+  const handleDeleteDeclaration = useCallback((declName: string) => {
+    const remaining = modelRef.current.declarations.filter((d) => d.name !== declName);
+    // Drop any properties (including relationships) and superType references to the deleted decl
+    const cleaned = remaining.map((d) => ({
+      ...d,
+      superType: d.superType === declName ? undefined : d.superType,
+      properties: (d.properties || []).filter((p) => p.type !== declName),
+    }));
+    updateModelAndSync(cleaned);
+  }, [updateModelAndSync]);
+
+  const handleToggleAbstract = useCallback((declName: string) => {
+    updateModelAndSync(
+      modelRef.current.declarations.map((d) => d.name === declName ? { ...d, isAbstract: !d.isAbstract } : d)
+    );
+  }, [updateModelAndSync]);
+
+  const handleAddProperty = useCallback((declName: string, propName: string, propType: string, isOptional: boolean, isArray: boolean, isRelationship: boolean) => {
+    updateModelAndSync(
+      modelRef.current.declarations.map((d) =>
+        d.name === declName
+          ? { ...d, properties: [...d.properties, { name: propName, type: propType, isOptional, isArray, isRelationship, validators: {} }] }
+          : d
+      )
+    );
+  }, [updateModelAndSync]);
+
+  const handleDeleteProperty = useCallback((declName: string, propName: string) => {
+    updateModelAndSync(
+      modelRef.current.declarations.map((d) =>
+        d.name === declName
+          ? { ...d, properties: d.properties.filter((p) => p.name !== propName) }
+          : d
+      )
+    );
+  }, [updateModelAndSync]);
+
+  const handleAddEnumValue = useCallback((declName: string, value: string) => {
+    updateModelAndSync(
+      modelRef.current.declarations.map((d) =>
+        d.name === declName ? { ...d, enumValues: [...d.enumValues, value] } : d
+      )
+    );
+  }, [updateModelAndSync]);
+
+  const handleDeleteEnumValue = useCallback((declName: string, value: string) => {
+    updateModelAndSync(
+      modelRef.current.declarations.map((d) =>
+        d.name === declName ? { ...d, enumValues: d.enumValues.filter((v) => v !== value) } : d
+      )
+    );
+  }, [updateModelAndSync]);
+
+  const handleSetSuperType = useCallback((declName: string, superType: string | undefined) => {
+    updateModelAndSync(
+      modelRef.current.declarations.map((d) => d.name === declName ? { ...d, superType } : d)
+    );
+  }, [updateModelAndSync]);
+
+  // Undo
+  const handleUndo = useCallback(() => {
+    if (historyIndex <= 0) return;
+    const newIndex = historyIndex - 1;
+    const entry = history[newIndex];
+    isUndoRedo.current = true;
+    setHistoryIndex(newIndex);
+    setModel(entry.model);
+    setNodes(entry.nodes);
+    setEdges(entry.edges);
+    // Restore positions from history
+    for (const node of entry.nodes) {
+      nodePositionsRef.current.set(node.id, { ...node.position });
+    }
+    updatingFromGraph.current = true;
+    onModelChange?.(declarationsToCto(entry.model));
+  }, [history, historyIndex, setNodes, setEdges, onModelChange]);
+
+  // Redo
+  const handleRedo = useCallback(() => {
+    if (historyIndex >= history.length - 1) return;
+    const newIndex = historyIndex + 1;
+    const entry = history[newIndex];
+    isUndoRedo.current = true;
+    setHistoryIndex(newIndex);
+    setModel(entry.model);
+    setNodes(entry.nodes);
+    setEdges(entry.edges);
+    for (const node of entry.nodes) {
+      nodePositionsRef.current.set(node.id, { ...node.position });
+    }
+    updatingFromGraph.current = true;
+    onModelChange?.(declarationsToCto(entry.model));
+  }, [history, historyIndex, setNodes, setEdges, onModelChange]);
+
+  // Keyboard shortcuts for undo/redo
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z') {
+        if (e.shiftKey) {
+          e.preventDefault();
+          handleRedo();
+        } else {
+          e.preventDefault();
+          handleUndo();
+        }
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'y') {
+        e.preventDefault();
+        handleRedo();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [handleUndo, handleRedo]);
+
+  const canUndo = historyIndex > 0;
+  const canRedo = historyIndex < history.length - 1;
+
+  // Save position after drag as a history entry
+  const onNodeDragStop = useCallback((_event: React.MouseEvent, _node: Node) => {
+    const currentNodes = nodes.map((n) => {
+      const pos = nodePositionsRef.current.get(n.id);
+      return pos ? { ...n, position: pos } : n;
+    });
+    pushHistory({ model: modelRef.current, nodes: currentNodes, edges });
+  }, [nodes, edges, pushHistory]);
+
+  // Drag edge between nodes → open connect dialog
+  const onConnect = useCallback((connection: Connection) => {
+    if (connection.source && connection.target && connection.source !== connection.target) {
+      setConnectDialog({ sourceId: connection.source, targetId: connection.target });
+    }
+  }, []);
+
+  const handleConnectSubmit = useCallback((connType: 'property' | 'relationship' | 'extends', propName: string) => {
+    if (!connectDialog) return;
+    const { sourceId, targetId } = connectDialog;
+    if (connType === 'extends') {
+      handleSetSuperType(sourceId, targetId);
+    } else {
+      handleAddProperty(sourceId, propName, targetId, false, false, connType === 'relationship');
+    }
+    setConnectDialog(null);
+  }, [connectDialog, handleSetSuperType, handleAddProperty]);
+
+  // Inject callbacks into nodes
+  const nodesWithCallbacks = nodes.map((node) => ({
+    ...node,
+    data: {
+      ...node.data,
+      onAddProperty: (declName: string) => setActiveDialog({ type: 'property', declName }),
+      onDeleteProperty: handleDeleteProperty,
+      onDeleteDeclaration: handleDeleteDeclaration,
+      onToggleAbstract: handleToggleAbstract,
+      onSetInheritance: (declName: string) => setActiveDialog({ type: 'inheritance', declName }),
+      onAddEnumValue: (declName: string) => setActiveDialog({ type: 'enum-value', declName }),
+      onDeleteEnumValue: handleDeleteEnumValue,
+    },
+  }));
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+      <Toolbar
+        declarations={model.declarations}
+        onAddDeclaration={handleAddDeclaration}
+        onAddProperty={handleAddProperty}
+        onAddEnumValue={handleAddEnumValue}
+        onSetSuperType={handleSetSuperType}
+        activeDialog={activeDialog}
+        onCloseDialog={() => setActiveDialog(null)}
+        onUndo={handleUndo}
+        onRedo={handleRedo}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        showText={showText}
+        onToggleText={onToggleText}
+        onImport={onImport}
+        onExport={onExport}
+      />
+      <div style={{ flex: 1, position: 'relative' }}>
+        <ReactFlow
+          nodes={nodesWithCallbacks}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onNodeDragStop={onNodeDragStop}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.3 }}
+          style={{ background: '#1a202c' }}
+          connectionLineStyle={{ stroke: '#63b3ed', strokeWidth: 2 }}
+          minZoom={0.05}
+          maxZoom={4}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background variant={BackgroundVariant.Dots} color="#4a5568" gap={20} size={1} />
+        </ReactFlow>
+
+        {connectDialog && (
+          <ConnectEdgeDialog
+            sourceId={connectDialog.sourceId}
+            targetId={connectDialog.targetId}
+            onSubmit={handleConnectSubmit}
+            onClose={() => setConnectDialog(null)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConnectEdgeDialog({ sourceId, targetId, onSubmit, onClose }: {
+  sourceId: string;
+  targetId: string;
+  onSubmit: (type: 'property' | 'relationship' | 'extends', name: string) => void;
+  onClose: () => void;
+}) {
+  const [connType, setConnType] = useState<'property' | 'relationship' | 'extends'>('property');
+  const [propName, setPropName] = useState('');
+
+  const handleSubmit = () => {
+    if (connType === 'extends') {
+      onSubmit('extends', '');
+    } else {
+      if (!propName.trim()) return;
+      onSubmit(connType, propName.trim());
+    }
+  };
+
+  return (
+    <div style={overlayStyle} onClick={onClose}>
+      <div style={dialogStyle} onClick={(e) => e.stopPropagation()}>
+        <h3 style={{ margin: '0 0 4px', color: '#e2e8f0', fontSize: 14 }}>
+          Connect: {sourceId} &rarr; {targetId}
+        </h3>
+        <p style={{ margin: '0 0 12px', color: '#a0aec0', fontSize: 12 }}>
+          How should these be related?
+        </p>
+
+        <div style={{ display: 'flex', gap: 6, marginBottom: 12 }}>
+          <button onClick={() => setConnType('property')}
+            style={{ ...typeBtnStyle, background: connType === 'property' ? '#3182ce' : '#4a5568' }}>
+            Property (o)
+          </button>
+          <button onClick={() => setConnType('relationship')}
+            style={{ ...typeBtnStyle, background: connType === 'relationship' ? '#e53e3e' : '#4a5568' }}>
+            Relationship (&rarr;)
+          </button>
+          <button onClick={() => setConnType('extends')}
+            style={{ ...typeBtnStyle, background: connType === 'extends' ? '#805ad5' : '#4a5568' }}>
+            Extends
+          </button>
+        </div>
+
+        {connType !== 'extends' && (
+          <input
+            value={propName}
+            onChange={(e) => setPropName(e.target.value)}
+            placeholder={`Property name (e.g. my${targetId})`}
+            style={inputStyle}
+            autoFocus
+            onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+          />
+        )}
+
+        <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+          <button onClick={handleSubmit} style={{
+            ...typeBtnStyle,
+            background: connType === 'property' ? '#3182ce' : connType === 'relationship' ? '#e53e3e' : '#805ad5',
+          }}>
+            Connect
+          </button>
+          <button onClick={onClose} style={typeBtnStyle}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+  background: 'rgba(0,0,0,0.5)', zIndex: 20,
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+};
+
+const dialogStyle: React.CSSProperties = {
+  background: '#2d3748', borderRadius: 12, padding: 24, minWidth: 360,
+  boxShadow: '0 8px 32px rgba(0,0,0,0.5)', border: '1px solid #4a5568',
+};
+
+const typeBtnStyle: React.CSSProperties = {
+  background: '#4a5568', color: '#e2e8f0', border: 'none', borderRadius: 6,
+  padding: '8px 14px', cursor: 'pointer', fontSize: 12, fontWeight: 600,
+  transition: 'background 0.15s',
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '10px 12px', background: '#1a202c', color: '#e2e8f0',
+  border: '1px solid #4a5568', borderRadius: 6, fontSize: 13,
+  outline: 'none', boxSizing: 'border-box',
+};
+

--- a/packages/ui-concerto-editor/src/components/CtoEditor.tsx
+++ b/packages/ui-concerto-editor/src/components/CtoEditor.tsx
@@ -1,0 +1,334 @@
+import { useRef, useCallback } from 'react';
+
+interface CtoEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  readOnly?: boolean;
+  error?: string | null;
+}
+
+// Colors matching our graph nodes
+const COLORS = {
+  keyword: '#63b3ed',      // concept, enum, asset, etc. (same as concept node accent)
+  abstract: '#b794f4',     // abstract keyword (same as extends edge)
+  namespace: '#718096',    // namespace, import
+  typePrimitive: '#68d391', // String (green, same as String in nodes)
+  typeInteger: '#63b3ed',   // Integer, Long, Double (blue)
+  typeBoolean: '#fbd38d',   // Boolean (yellow)
+  typeDateTime: '#d6bcfa',  // DateTime (purple)
+  typeCustom: '#63b3ed',    // custom types (concept references)
+  relationship: '#fc8181',  // --> (red, same as relationship edge)
+  enumValue: '#fbd38d',     // enum values (yellow, same as enum node)
+  propName: '#e2e8f0',      // property names (white)
+  optional: '#ed8936',      // optional keyword (orange)
+  extends: '#b794f4',       // extends keyword (purple, same as extends edge)
+  brace: '#718096',         // { }
+  comment: '#4a5568',       // comments
+  identifier: '#fff',       // declaration names
+  o: '#718096',             // the 'o' marker
+};
+
+function highlightCto(cto: string): string {
+  try {
+  return cto.split('\n').map((line) => {
+    const trimmed = line.trim();
+
+    // Comments
+    if (trimmed.startsWith('//')) {
+      return `<span style="color:${COLORS.comment}">${esc(line)}</span>`;
+    }
+
+    // Namespace / import
+    if (trimmed.startsWith('namespace') || trimmed.startsWith('import')) {
+      return `<span style="color:${COLORS.namespace}">${esc(line)}</span>`;
+    }
+
+    // Decorator
+    const decoMatch = trimmed.match(/^(@\w+(?:\([^)]*\))?)$/);
+    if (decoMatch) {
+      return `${getIndent(line)}<span style="color:#fbb6ce">${esc(decoMatch[1])}</span>`;
+    }
+
+    // Scalar
+    const scalarMatch = trimmed.match(/^(scalar)\s+(\w+)\s+(extends)\s+(\w+)(.*)$/);
+    if (scalarMatch) {
+      let result = getIndent(line);
+      result += `<span style="color:${COLORS.keyword}">scalar</span> `;
+      result += `<span style="color:${COLORS.identifier};font-weight:700">${scalarMatch[2]}</span> `;
+      result += `<span style="color:${COLORS.extends}">extends</span> `;
+      result += `<span style="color:${colorForType(scalarMatch[4])}">${scalarMatch[4]}</span>`;
+      if (scalarMatch[5]) result += `<span style="color:${COLORS.optional}">${esc(scalarMatch[5])}</span>`;
+      return result;
+    }
+
+    // Declaration line
+    const declMatch = trimmed.match(
+      /^(abstract\s+)?(concept|enum|asset|participant|event|transaction|map)\s+(\w+)(.*?)\s*(\{)?$/
+    );
+    if (declMatch) {
+      let result = getIndent(line);
+      if (declMatch[1]) result += `<span style="color:${COLORS.abstract}">abstract</span> `;
+      result += `<span style="color:${COLORS.keyword}">${declMatch[2]}</span> `;
+      result += `<span style="color:${COLORS.identifier};font-weight:700">${declMatch[3]}</span>`;
+      const rest = declMatch[4] || '';
+      // Escape first, then inject styled spans via regex replace. This preserves
+      // partial text during typing (e.g. "identi" before full "identified") instead
+      // of dropping unmatched portions from the highlighted output.
+      let styledRest = esc(rest);
+      styledRest = styledRest.replace(
+        /(identified\s+by)\s+(\w+)/,
+        `<span style="color:#68d391">$1</span> <span style="color:${COLORS.propName}">$2</span>`
+      );
+      if (!/identified\s+by/.test(rest)) {
+        styledRest = styledRest.replace(
+          /\bidentified\b/,
+          `<span style="color:#68d391">identified</span>`
+        );
+      }
+      styledRest = styledRest.replace(
+        /(extends)\s+(\w+)/,
+        `<span style="color:${COLORS.extends}">$1</span> <span style="color:${COLORS.identifier}">$2</span>`
+      );
+      result += styledRest;
+      if (declMatch[5]) result += ` <span style="color:${COLORS.brace}">{</span>`;
+      return result;
+    }
+
+    // Braces
+    if (trimmed === '{') return `${getIndent(line)}<span style="color:${COLORS.brace}">{</span>`;
+    if (trimmed === '}') return `${getIndent(line)}<span style="color:${COLORS.brace}">}</span>`;
+
+    // Relationship: --> Type[] name ...
+    const relMatch = trimmed.match(/^(-->)\s+(\w+)(\[\])?\s+(\w+)(.*?)$/);
+    if (relMatch) {
+      let result = getIndent(line);
+      result += `<span style="color:${COLORS.relationship};font-weight:700">--&gt;</span> `;
+      result += `<span style="color:${colorForType(relMatch[2])}">${relMatch[2]}</span>`;
+      if (relMatch[3]) result += `<span style="color:${COLORS.typeInteger}">[]</span>`;
+      result += ` <span style="color:${COLORS.propName}">${relMatch[4]}</span>`;
+      if (relMatch[5]) result += highlightModifiers(relMatch[5]);
+      return result;
+    }
+
+    // Property: o Type[] name ...
+    const propMatch = trimmed.match(/^(o)\s+(\w+)(\[\])?\s+(\w+)(.*?)$/);
+    if (propMatch) {
+      let result = getIndent(line);
+      result += `<span style="color:${COLORS.o}">o</span> `;
+      result += `<span style="color:${colorForType(propMatch[2])}">${propMatch[2]}</span>`;
+      if (propMatch[3]) result += `<span style="color:${COLORS.typeInteger}">[]</span>`;
+      result += ` <span style="color:${COLORS.propName}">${propMatch[4]}</span>`;
+      if (propMatch[5]) result += highlightModifiers(propMatch[5]);
+      return result;
+    }
+
+    // Enum value: o ValueName
+    const enumValMatch = trimmed.match(/^(o)\s+(\w+)$/);
+    if (enumValMatch) {
+      let result = getIndent(line);
+      result += `<span style="color:${COLORS.o}">o</span> `;
+      result += `<span style="color:${COLORS.enumValue}">${enumValMatch[2]}</span>`;
+      return result;
+    }
+
+    // Map field: o Type (no name)
+    const mapFieldMatch = trimmed.match(/^(o)\s+(\w+)$/);
+    if (mapFieldMatch) {
+      let result = getIndent(line);
+      result += `<span style="color:${COLORS.o}">o</span> `;
+      result += `<span style="color:${colorForType(mapFieldMatch[2])}">${mapFieldMatch[2]}</span>`;
+      return result;
+    }
+
+    return esc(line);
+  }).join('\n');
+  } catch {
+    return esc(cto);
+  }
+}
+
+function highlightModifiers(str: string): string {
+  let result = str;
+  result = result.replace(/\boptional\b/g, `<span style="color:${COLORS.optional}">optional</span>`);
+  result = result.replace(/\bdefault\s*=\s*("(?:[^"\\]|\\.)*"|\S+)/g, `<span style="color:${COLORS.optional}">default=$1</span>`);
+  result = result.replace(/\bregex\s*=\s*(\/[^/]*\/)/g, `<span style="color:${COLORS.optional}">regex=$1</span>`);
+  result = result.replace(/\brange\s*=\s*(\[[^\]]*\])/g, `<span style="color:${COLORS.optional}">range=$1</span>`);
+  result = result.replace(/\blength\s*=\s*(\[[^\]]*\])/g, `<span style="color:${COLORS.optional}">length=$1</span>`);
+  return result;
+}
+
+function colorForType(type: string): string {
+  switch (type) {
+    case 'String': return COLORS.typePrimitive;
+    case 'Integer': case 'Long': case 'Double': return COLORS.typeInteger;
+    case 'Boolean': return COLORS.typeBoolean;
+    case 'DateTime': return COLORS.typeDateTime;
+    default: return COLORS.typeCustom;
+  }
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function getIndent(line: string): string {
+  const match = line.match(/^(\s*)/);
+  return match ? match[1] : '';
+}
+
+export function CtoEditor({ value, onChange, readOnly = false, error = null }: CtoEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const preRef = useRef<HTMLPreElement>(null);
+
+  const handleScroll = useCallback(() => {
+    if (textareaRef.current && preRef.current) {
+      preRef.current.scrollTop = textareaRef.current.scrollTop;
+      preRef.current.scrollLeft = textareaRef.current.scrollLeft;
+    }
+  }, []);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== 'Tab') return;
+    e.preventDefault();
+    const ta = e.currentTarget;
+    const { selectionStart: start, selectionEnd: end, value: v } = ta;
+    const INDENT = '  '; // 2 spaces, matches tabSize
+
+    // Multi-line selection: indent / dedent each line
+    if (start !== end && v.slice(start, end).includes('\n')) {
+      const lineStart = v.lastIndexOf('\n', start - 1) + 1;
+      const block = v.slice(lineStart, end);
+      const lines = block.split('\n');
+      const transformed = e.shiftKey
+        ? lines.map((l) => l.startsWith(INDENT) ? l.slice(INDENT.length) : l.replace(/^\t/, ''))
+        : lines.map((l) => INDENT + l);
+      const newBlock = transformed.join('\n');
+      const newValue = v.slice(0, lineStart) + newBlock + v.slice(end);
+      const diff = newBlock.length - block.length;
+      onChange(newValue);
+      requestAnimationFrame(() => {
+        ta.selectionStart = start + (e.shiftKey ? -INDENT.length : INDENT.length);
+        ta.selectionEnd = end + diff;
+      });
+      return;
+    }
+
+    // Single caret / single-line selection: insert / remove indent at caret
+    if (e.shiftKey) {
+      const lineStart = v.lastIndexOf('\n', start - 1) + 1;
+      const lineText = v.slice(lineStart, start);
+      if (lineText.startsWith(INDENT)) {
+        const newValue = v.slice(0, lineStart) + lineText.slice(INDENT.length) + v.slice(start);
+        onChange(newValue);
+        requestAnimationFrame(() => {
+          ta.selectionStart = ta.selectionEnd = start - INDENT.length;
+        });
+      }
+      return;
+    }
+    const newValue = v.slice(0, start) + INDENT + v.slice(end);
+    onChange(newValue);
+    requestAnimationFrame(() => {
+      ta.selectionStart = ta.selectionEnd = start + INDENT.length;
+    });
+  }, [onChange]);
+
+  return (
+    <div style={containerStyle}>
+      <style>{`
+        .cto-editor-textarea::selection {
+          background: rgba(99, 179, 237, 0.25);
+          color: transparent;
+        }
+      `}</style>
+      {/* Highlighted layer (behind) */}
+      <pre
+        ref={preRef}
+        style={preStyle}
+        dangerouslySetInnerHTML={{ __html: highlightCto(value) + '\n' }}
+      />
+      {/* Editable textarea (on top, transparent text) */}
+      <textarea
+        ref={textareaRef}
+        className="cto-editor-textarea"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onScroll={handleScroll}
+        style={textareaStyle}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        readOnly={readOnly}
+      />
+      {error && (
+        <div style={errorBannerStyle} title={error}>
+          <span style={{ fontWeight: 700, marginRight: 6 }}>!</span>
+          {error.length > 120 ? error.slice(0, 120) + '...' : error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const font = "'Fira Code', 'Cascadia Code', 'JetBrains Mono', 'Consolas', monospace";
+
+const containerStyle: React.CSSProperties = {
+  position: 'relative',
+  flex: 1,
+  overflow: 'hidden',
+};
+
+const sharedStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 0, left: 0, right: 0, bottom: 0,
+  padding: 16,
+  fontFamily: font,
+  fontSize: 13,
+  lineHeight: 1.6,
+  whiteSpace: 'pre-wrap',
+  wordWrap: 'break-word',
+  overflowWrap: 'break-word',
+  tabSize: 2,
+  margin: 0,
+  border: 'none',
+  outline: 'none',
+};
+
+const preStyle: React.CSSProperties = {
+  ...sharedStyle,
+  background: '#1a202c',
+  color: '#e2e8f0',
+  overflow: 'auto',
+  pointerEvents: 'none',
+};
+
+const textareaStyle: React.CSSProperties = {
+  ...sharedStyle,
+  background: 'transparent',
+  color: 'transparent',
+  caretColor: '#e2e8f0',
+  resize: 'none',
+  overflow: 'auto',
+  zIndex: 1,
+};
+
+const errorBannerStyle: React.CSSProperties = {
+  position: 'absolute',
+  bottom: 12,
+  left: 12,
+  right: 12,
+  padding: '8px 12px',
+  background: 'rgba(254, 178, 178, 0.12)',
+  border: '1px solid #fc8181',
+  borderRadius: 6,
+  color: '#fc8181',
+  fontFamily: font,
+  fontSize: 11,
+  lineHeight: 1.4,
+  zIndex: 2,
+  pointerEvents: 'auto',
+  cursor: 'help',
+  maxHeight: 80,
+  overflow: 'hidden',
+};

--- a/packages/ui-concerto-editor/src/components/EnumNode.tsx
+++ b/packages/ui-concerto-editor/src/components/EnumNode.tsx
@@ -1,0 +1,81 @@
+import { Handle, Position } from '@xyflow/react';
+import type { Declaration } from '../utils/types';
+
+interface EnumNodeData {
+  label: string;
+  declaration: Declaration;
+  onAddEnumValue?: (declName: string) => void;
+  onDeleteEnumValue?: (declName: string, value: string) => void;
+  onDeleteDeclaration?: (declName: string) => void;
+}
+
+export function EnumNode({ data, selected }: { data: EnumNodeData; selected?: boolean }) {
+  const { declaration } = data;
+
+  return (
+    <div style={{
+      background: '#1e2533',
+      borderRadius: 12,
+      border: `2px solid ${selected ? '#fff' : '#d69e2e66'}`,
+      minWidth: 200,
+      boxShadow: selected
+        ? '0 0 20px #d69e2e44, 0 8px 24px rgba(0,0,0,0.4)'
+        : '0 4px 16px rgba(0,0,0,0.3)',
+      overflow: 'hidden',
+      transition: 'border-color 0.2s, box-shadow 0.2s',
+    }}>
+      <Handle type="target" position={Position.Top} id="top" style={handleStyle} />
+      <Handle type="target" position={Position.Left} id="left" style={handleStyle} />
+      <Handle type="source" position={Position.Right} id="right" style={handleStyle} />
+
+      {/* Header */}
+      <div style={{
+        padding: '12px 14px 10px',
+        background: 'linear-gradient(135deg, #744210, #744210cc)',
+        borderBottom: '1px solid #d69e2e33',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 9, letterSpacing: 1.5, textTransform: 'uppercase', color: '#ecc94b', fontWeight: 700 }}>
+            enum
+          </span>
+          <button onClick={() => data.onDeleteDeclaration?.(declaration.name)}
+            style={{ background: 'none', border: 'none', color: '#ffffff55', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}>
+            &times;
+          </button>
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 700, marginTop: 4, color: '#fefcbf' }}>
+          {declaration.name}
+        </div>
+      </div>
+
+      {/* Values */}
+      <div style={{ padding: '6px 6px 8px' }}>
+        {declaration.enumValues.map((val) => (
+          <div key={val} style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            padding: '5px 8px', margin: '2px 0', background: '#161b27', borderRadius: 6,
+          }}>
+            <span style={{ color: '#fbd38d', fontSize: 12 }}>{val}</span>
+            <button onClick={() => data.onDeleteEnumValue?.(declaration.name, val)}
+              style={{ background: 'none', border: 'none', color: '#ffffff22', cursor: 'pointer', fontSize: 13, padding: 0, lineHeight: 1 }}>
+              &times;
+            </button>
+          </div>
+        ))}
+        <button onClick={() => data.onAddEnumValue?.(declaration.name)} style={{
+          background: 'transparent', border: '1px dashed #d69e2e44',
+          color: '#d69e2eaa', cursor: 'pointer', fontSize: 11, fontWeight: 600,
+          padding: '5px 0', marginTop: 4, borderRadius: 6, width: '100%', textAlign: 'center',
+        }}>
+          + Add Value
+        </button>
+      </div>
+
+      <Handle type="source" position={Position.Bottom} id="bottom" style={handleStyle} />
+    </div>
+  );
+}
+
+const handleStyle: React.CSSProperties = {
+  width: 10, height: 10, background: '#ecc94b', borderRadius: '50%', border: '2px solid #1e2533',
+};

--- a/packages/ui-concerto-editor/src/components/FloatingEdge.tsx
+++ b/packages/ui-concerto-editor/src/components/FloatingEdge.tsx
@@ -1,0 +1,78 @@
+import { getBezierPath, useInternalNode, EdgeLabelRenderer, BaseEdge, Position, type EdgeProps } from '@xyflow/react';
+
+type XY = { x: number; y: number };
+type NodeLike = { internals: { positionAbsolute: XY }; measured: { width?: number; height?: number } };
+
+// Pick the closest point on the node's rectangle to the other node's center,
+// and return both the point and the side (Position) it sits on.
+function getClosestPoint(source: NodeLike, target: NodeLike): { x: number; y: number; position: Position } {
+  const w = source.measured.width ?? 0;
+  const h = source.measured.height ?? 0;
+  const sx = source.internals.positionAbsolute.x;
+  const sy = source.internals.positionAbsolute.y;
+  const tx = target.internals.positionAbsolute.x + (target.measured.width ?? 0) / 2;
+  const ty = target.internals.positionAbsolute.y + (target.measured.height ?? 0) / 2;
+
+  const cx = sx + w / 2;
+  const cy = sy + h / 2;
+
+  const dx = tx - cx;
+  const dy = ty - cy;
+
+  // Scale so the point lies on the rectangle's perimeter
+  const absDx = Math.abs(dx);
+  const absDy = Math.abs(dy);
+  const scale = absDx / (w / 2) > absDy / (h / 2) ? (w / 2) / absDx : (h / 2) / absDy;
+
+  const x = cx + dx * scale;
+  const y = cy + dy * scale;
+
+  let position: Position;
+  if (absDx / (w / 2) > absDy / (h / 2)) {
+    position = dx > 0 ? Position.Right : Position.Left;
+  } else {
+    position = dy > 0 ? Position.Bottom : Position.Top;
+  }
+
+  return { x, y, position };
+}
+
+export function FloatingEdge({ id, source, target, style, markerEnd, label, labelStyle, labelBgStyle, labelBgPadding, labelBgBorderRadius }: EdgeProps) {
+  const sourceNode = useInternalNode(source);
+  const targetNode = useInternalNode(target);
+  if (!sourceNode || !targetNode) return null;
+
+  const sp = getClosestPoint(sourceNode as unknown as NodeLike, targetNode as unknown as NodeLike);
+  const tp = getClosestPoint(targetNode as unknown as NodeLike, sourceNode as unknown as NodeLike);
+
+  const [path, labelX, labelY] = getBezierPath({
+    sourceX: sp.x, sourceY: sp.y, sourcePosition: sp.position,
+    targetX: tp.x, targetY: tp.y, targetPosition: tp.position,
+  });
+
+  return (
+    <>
+      <BaseEdge id={id} path={path} style={style} markerEnd={markerEnd} />
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: 'none',
+              padding: Array.isArray(labelBgPadding) ? `${labelBgPadding[1]}px ${labelBgPadding[0]}px` : '3px 6px',
+              borderRadius: labelBgBorderRadius ?? 4,
+              background: (labelBgStyle as any)?.fill ?? '#1a202c',
+              opacity: (labelBgStyle as any)?.fillOpacity ?? 0.8,
+              color: (labelStyle as any)?.fill ?? '#fff',
+              fontSize: (labelStyle as any)?.fontSize ?? 10,
+              fontWeight: (labelStyle as any)?.fontWeight ?? 500,
+            }}
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}

--- a/packages/ui-concerto-editor/src/components/MapNode.tsx
+++ b/packages/ui-concerto-editor/src/components/MapNode.tsx
@@ -1,0 +1,77 @@
+import { Handle, Position } from '@xyflow/react';
+import type { Declaration } from '../utils/types';
+
+interface MapNodeData {
+  label: string;
+  declaration: Declaration;
+  onDeleteDeclaration?: (declName: string) => void;
+}
+
+export function MapNode({ data, selected }: { data: MapNodeData; selected?: boolean }) {
+  const { declaration } = data;
+  const map = declaration.mapDeclaration;
+
+  return (
+    <div style={{
+      background: '#1e2533',
+      borderRadius: 12,
+      border: `2px solid ${selected ? '#fff' : '#38b2ac66'}`,
+      minWidth: 210,
+      boxShadow: selected
+        ? '0 0 20px #38b2ac44, 0 8px 24px rgba(0,0,0,0.4)'
+        : '0 4px 16px rgba(0,0,0,0.3)',
+      overflow: 'hidden',
+      transition: 'border-color 0.2s, box-shadow 0.2s',
+    }}>
+      <Handle type="target" position={Position.Top} id="top" style={handleStyle} />
+      <Handle type="target" position={Position.Left} id="left" style={handleStyle} />
+      <Handle type="source" position={Position.Right} id="right" style={handleStyle} />
+
+      <div style={{
+        padding: '12px 14px 10px',
+        background: 'linear-gradient(135deg, #234e52, #234e52cc)',
+        borderBottom: '1px solid #38b2ac33',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 9, letterSpacing: 1.5, textTransform: 'uppercase', color: '#81e6d9', fontWeight: 700 }}>
+            map
+          </span>
+          <button onClick={() => data.onDeleteDeclaration?.(declaration.name)}
+            style={{ background: 'none', border: 'none', color: '#ffffff55', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}>
+            &times;
+          </button>
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 700, marginTop: 4, color: '#b2f5ea' }}>
+          {declaration.name}
+        </div>
+      </div>
+
+      <div style={{ padding: '6px 6px 8px' }}>
+        {map && (
+          <>
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              padding: '5px 8px', margin: '2px 0', background: '#161b27', borderRadius: 6,
+            }}>
+              <span style={{ fontSize: 10, color: '#a0aec0', textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 600 }}>Key</span>
+              <span style={{ fontSize: 12, color: '#81e6d9', fontFamily: "'JetBrains Mono', monospace", fontWeight: 600 }}>{map.keyType}</span>
+            </div>
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              padding: '5px 8px', margin: '2px 0', background: '#161b27', borderRadius: 6,
+            }}>
+              <span style={{ fontSize: 10, color: '#a0aec0', textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 600 }}>Value</span>
+              <span style={{ fontSize: 12, color: '#81e6d9', fontFamily: "'JetBrains Mono', monospace", fontWeight: 600 }}>{map.valueType}</span>
+            </div>
+          </>
+        )}
+      </div>
+
+      <Handle type="source" position={Position.Bottom} id="bottom" style={handleStyle} />
+    </div>
+  );
+}
+
+const handleStyle: React.CSSProperties = {
+  width: 10, height: 10, background: '#38b2ac', borderRadius: '50%', border: '2px solid #1e2533',
+};

--- a/packages/ui-concerto-editor/src/components/ScalarNode.tsx
+++ b/packages/ui-concerto-editor/src/components/ScalarNode.tsx
@@ -1,0 +1,102 @@
+import { Handle, Position } from '@xyflow/react';
+import type { Declaration } from '../utils/types';
+
+interface ScalarNodeData {
+  label: string;
+  declaration: Declaration;
+  onDeleteDeclaration?: (declName: string) => void;
+}
+
+export function ScalarNode({ data, selected }: { data: ScalarNodeData; selected?: boolean }) {
+  const { declaration } = data;
+  const v = declaration.scalarValidators || {};
+
+  return (
+    <div style={{
+      background: '#1e2533',
+      borderRadius: 12,
+      border: `2px solid ${selected ? '#fff' : '#ed64a666'}`,
+      minWidth: 200,
+      boxShadow: selected
+        ? '0 0 20px #ed64a644, 0 8px 24px rgba(0,0,0,0.4)'
+        : '0 4px 16px rgba(0,0,0,0.3)',
+      overflow: 'hidden',
+      transition: 'border-color 0.2s, box-shadow 0.2s',
+    }}>
+      <Handle type="target" position={Position.Top} style={handleStyle} />
+
+      <div style={{
+        padding: '10px 14px',
+        background: 'linear-gradient(135deg, #702459, #702459cc)',
+        borderBottom: '1px solid #ed64a633',
+      }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span style={{ fontSize: 9, letterSpacing: 1.5, textTransform: 'uppercase', color: '#ed64a6', fontWeight: 700 }}>
+            scalar
+          </span>
+          <button onClick={() => data.onDeleteDeclaration?.(declaration.name)}
+            style={{ background: 'none', border: 'none', color: '#ffffff55', cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: 0 }}>
+            &times;
+          </button>
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 700, marginTop: 4, color: '#fbb6ce' }}>
+          {declaration.name}
+        </div>
+        <div style={{ fontSize: 11, color: '#ed64a6', marginTop: 2 }}>
+          extends {declaration.scalarExtends || 'String'}
+        </div>
+      </div>
+
+      <div style={{ padding: '6px 12px 8px' }}>
+        {v.default && (
+          <div style={detailRow}>
+            <span style={detailLabel}>default</span>
+            <span style={detailValue}>{v.default}</span>
+          </div>
+        )}
+        {v.regex && (
+          <div style={detailRow}>
+            <span style={detailLabel}>regex</span>
+            <span style={detailValue}>{v.regex}</span>
+          </div>
+        )}
+        {v.range && (
+          <div style={detailRow}>
+            <span style={detailLabel}>range</span>
+            <span style={detailValue}>{v.range}</span>
+          </div>
+        )}
+        {v.length && (
+          <div style={detailRow}>
+            <span style={detailLabel}>length</span>
+            <span style={detailValue}>{v.length}</span>
+          </div>
+        )}
+        {!v.default && !v.regex && !v.range && !v.length && (
+          <div style={{ fontSize: 11, color: '#ffffff33', padding: '4px 0', textAlign: 'center', fontStyle: 'italic' }}>
+            no constraints
+          </div>
+        )}
+      </div>
+
+      <Handle type="source" position={Position.Bottom} style={handleStyle} />
+    </div>
+  );
+}
+
+const handleStyle: React.CSSProperties = {
+  width: 10, height: 10, background: '#ed64a6', borderRadius: '50%', border: '2px solid #1e2533',
+};
+
+const detailRow: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+  padding: '4px 8px', margin: '2px 0', background: '#161b27', borderRadius: 6,
+};
+
+const detailLabel: React.CSSProperties = {
+  fontSize: 10, color: '#a0aec0', textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 600,
+};
+
+const detailValue: React.CSSProperties = {
+  fontSize: 11, color: '#fbb6ce', fontFamily: 'monospace',
+};

--- a/packages/ui-concerto-editor/src/components/Toolbar.tsx
+++ b/packages/ui-concerto-editor/src/components/Toolbar.tsx
@@ -1,0 +1,348 @@
+import { useState } from 'react';
+import type { Declaration } from '../utils/types';
+import { DECLARATION_TYPES, ALL_TYPES, getAvailableTypes, getExtendsCandidates, getMapKeyTypes, getMapValueTypes } from '../utils/types';
+
+interface ToolbarProps {
+  declarations: Declaration[];
+  onAddDeclaration: (decl: Declaration) => void;
+  onAddProperty: (declName: string, propName: string, propType: string, isOptional: boolean, isArray: boolean, isRelationship: boolean) => void;
+  onAddEnumValue: (declName: string, value: string) => void;
+  onSetSuperType: (declName: string, superType: string | undefined) => void;
+  activeDialog: { type: 'property' | 'enum-value' | 'inheritance'; declName: string } | null;
+  onCloseDialog: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  showText: boolean;
+  onToggleText: () => void;
+  onImport: () => void;
+  onExport: () => void;
+}
+
+export function Toolbar({ declarations, onAddDeclaration, onAddProperty, onAddEnumValue, onSetSuperType, activeDialog, onCloseDialog, onUndo, onRedo, canUndo, canRedo, showText, onToggleText, onImport, onExport }: ToolbarProps) {
+  const [showAddDecl, setShowAddDecl] = useState(false);
+
+  return (
+    <div style={toolbarStyle}>
+      {/* Left group: CTO toggle, file ops */}
+      <button onClick={onToggleText}
+        style={{ ...pillBtn, background: showText ? '#3182ce' : '#4a5568' }}
+        title={showText ? 'Hide CTO text' : 'Show CTO text'}>
+        {showText ? '\u25C0 CTO' : '\u25B6 CTO'}
+      </button>
+      <button onClick={onImport} style={pillBtn}>Import</button>
+      <button onClick={onExport} style={pillBtn}>Export</button>
+
+      <div style={sep} />
+
+      {/* Middle group: editing tools */}
+      <button onClick={() => setShowAddDecl(true)} style={{ ...pillBtn, background: '#3182ce' }}>+ Add</button>
+
+      <div style={sep} />
+
+      <button onClick={onUndo} disabled={!canUndo}
+        style={{ ...arrowBtn, opacity: canUndo ? 1 : 0.25 }}
+        title="Undo (Ctrl+Z)">
+        {'↩'}
+      </button>
+      <button onClick={onRedo} disabled={!canRedo}
+        style={{ ...arrowBtn, opacity: canRedo ? 1 : 0.25 }}
+        title="Redo (Ctrl+Shift+Z)">
+        {'↪'}
+      </button>
+
+      {/* Right group: legend */}
+      <div style={legendStyle}>
+        <span style={legendItem}><span style={{ ...dot, background: '#63b3ed' }} />property</span>
+        <span style={legendItem}><span style={{ ...dot, background: '#fc8181' }} />relationship</span>
+        <span style={legendItem}><span style={{ ...dot, background: '#b794f4' }} />extends</span>
+      </div>
+
+      {showAddDecl && (
+        <AddDeclarationDialog
+          declarations={declarations}
+          onAdd={(decl) => { onAddDeclaration(decl); setShowAddDecl(false); }}
+          onClose={() => setShowAddDecl(false)}
+        />
+      )}
+
+      {activeDialog?.type === 'property' && (
+        <AddPropertyDialog
+          declName={activeDialog.declName}
+          declarations={declarations}
+          onAdd={(propName, propType, isOptional, isArray, isRelationship) => {
+            onAddProperty(activeDialog.declName, propName, propType, isOptional, isArray, isRelationship);
+            onCloseDialog();
+          }}
+          onClose={onCloseDialog}
+        />
+      )}
+
+      {activeDialog?.type === 'enum-value' && (
+        <AddEnumValueDialog
+          declName={activeDialog.declName}
+          onAdd={(value) => { onAddEnumValue(activeDialog.declName, value); onCloseDialog(); }}
+          onClose={onCloseDialog}
+        />
+      )}
+
+      {activeDialog?.type === 'inheritance' && (
+        <SetInheritanceDialog
+          declName={activeDialog.declName}
+          declarations={declarations}
+          onSet={(superType) => { onSetSuperType(activeDialog.declName, superType); onCloseDialog(); }}
+          onClose={onCloseDialog}
+        />
+      )}
+    </div>
+  );
+}
+
+function AddDeclarationDialog({ declarations, onAdd, onClose }: {
+  declarations: Declaration[];
+  onAdd: (decl: Declaration) => void;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [type, setType] = useState<Declaration['type']>('concept');
+  const [mapKeyType, setMapKeyType] = useState('String');
+  const [mapValueType, setMapValueType] = useState('String');
+
+  const allTypeOptions = getAvailableTypes(declarations);
+  const mapKeyOptions = getMapKeyTypes(declarations);
+  const mapValueOptions = getMapValueTypes(declarations);
+
+  const [scalarExtends, setScalarExtends] = useState('String');
+
+  const handleSubmit = () => {
+    if (!name.trim()) return;
+    const decl: Declaration = {
+      name: name.trim(), type, isAbstract: false,
+      properties: [], enumValues: [],
+      identified: 'none', decorators: [],
+    };
+    if (type === 'map') {
+      decl.mapDeclaration = { keyType: mapKeyType, valueType: mapValueType };
+    }
+    if (type === 'scalar') {
+      decl.scalarExtends = scalarExtends;
+      decl.scalarValidators = {};
+    }
+    onAdd(decl);
+  };
+
+  return (
+    <div style={dialogOverlay} onClick={onClose}>
+      <div style={dialogStyle} onClick={(e) => e.stopPropagation()}>
+        <h3 style={dialogTitle}>Add Declaration</h3>
+        <select value={type} onChange={(e) => setType(e.target.value as Declaration['type'])} style={inputStyle}>
+          {DECLARATION_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+        </select>
+        <input value={name} onChange={(e) => setName(e.target.value)}
+          placeholder="Name (e.g. MyContract)" style={inputStyle} autoFocus
+          onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+        />
+        {type === 'scalar' && (
+          <>
+            <label style={fieldLabel}>Extends primitive</label>
+            <select value={scalarExtends} onChange={(e) => setScalarExtends(e.target.value)} style={inputStyle}>
+              {ALL_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </>
+        )}
+        {type === 'map' && (
+          <>
+            <label style={fieldLabel}>Key Type</label>
+            <select value={mapKeyType} onChange={(e) => setMapKeyType(e.target.value)} style={inputStyle}>
+              {mapKeyOptions.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+            <label style={fieldLabel}>Value Type</label>
+            <select value={mapValueType} onChange={(e) => setMapValueType(e.target.value)} style={inputStyle}>
+              {mapValueOptions.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </>
+        )}
+        <div style={dialogButtons}>
+          <button onClick={handleSubmit} style={{ ...btnStyle, background: '#3182ce' }}>Add</button>
+          <button onClick={onClose} style={btnStyle}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AddPropertyDialog({ declName, declarations, onAdd, onClose }: {
+  declName: string;
+  declarations: Declaration[];
+  onAdd: (name: string, type: string, isOptional: boolean, isArray: boolean, isRelationship: boolean) => void;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [type, setType] = useState('String');
+  const [isOptional, setIsOptional] = useState(false);
+  const [isArray, setIsArray] = useState(false);
+  const [isRelationship, setIsRelationship] = useState(false);
+
+  const availableTypes = getAvailableTypes(declarations, declName);
+
+  const handleSubmit = () => {
+    if (!name.trim()) return;
+    onAdd(name.trim(), type, isOptional, isArray, isRelationship);
+  };
+
+  return (
+    <div style={dialogOverlay} onClick={onClose}>
+      <div style={dialogStyle} onClick={(e) => e.stopPropagation()}>
+        <h3 style={dialogTitle}>Add Property to {declName}</h3>
+        <select value={type} onChange={(e) => setType(e.target.value)} style={inputStyle}>
+          {availableTypes.map((t) => <option key={t} value={t}>{t}</option>)}
+        </select>
+        <input value={name} onChange={(e) => setName(e.target.value)}
+          placeholder="Property name" style={inputStyle} autoFocus
+          onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+        />
+        <div style={{ display: 'flex', gap: 16, marginTop: 8 }}>
+          <label style={checkboxLabel}>
+            <input type="checkbox" checked={isOptional} onChange={(e) => setIsOptional(e.target.checked)} /> optional
+          </label>
+          <label style={checkboxLabel}>
+            <input type="checkbox" checked={isArray} onChange={(e) => setIsArray(e.target.checked)} /> array []
+          </label>
+          <label style={checkboxLabel}>
+            <input type="checkbox" checked={isRelationship} onChange={(e) => setIsRelationship(e.target.checked)} />
+            relationship (--&gt;)
+          </label>
+        </div>
+        <div style={dialogButtons}>
+          <button onClick={handleSubmit} style={{ ...btnStyle, background: '#3182ce' }}>Add</button>
+          <button onClick={onClose} style={btnStyle}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AddEnumValueDialog({ declName, onAdd, onClose }: {
+  declName: string;
+  onAdd: (value: string) => void;
+  onClose: () => void;
+}) {
+  const [value, setValue] = useState('');
+  const handleSubmit = () => { if (value.trim()) onAdd(value.trim()); };
+
+  return (
+    <div style={dialogOverlay} onClick={onClose}>
+      <div style={dialogStyle} onClick={(e) => e.stopPropagation()}>
+        <h3 style={dialogTitle}>Add Value to {declName}</h3>
+        <input value={value} onChange={(e) => setValue(e.target.value)}
+          placeholder="Value (e.g. Active)" style={inputStyle} autoFocus
+          onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+        />
+        <div style={dialogButtons}>
+          <button onClick={handleSubmit} style={{ ...btnStyle, background: '#d69e2e' }}>Add</button>
+          <button onClick={onClose} style={btnStyle}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SetInheritanceDialog({ declName, declarations, onSet, onClose }: {
+  declName: string;
+  declarations: Declaration[];
+  onSet: (superType: string | undefined) => void;
+  onClose: () => void;
+}) {
+  const [superType, setSuperType] = useState('');
+  const candidates = getExtendsCandidates(declarations, declName);
+
+  return (
+    <div style={dialogOverlay} onClick={onClose}>
+      <div style={dialogStyle} onClick={(e) => e.stopPropagation()}>
+        <h3 style={dialogTitle}>Set Inheritance for {declName}</h3>
+        <select value={superType} onChange={(e) => setSuperType(e.target.value)} style={inputStyle}>
+          <option value="">None (no inheritance)</option>
+          {candidates.map((c) => <option key={c} value={c}>{c}</option>)}
+        </select>
+        <div style={dialogButtons}>
+          <button onClick={() => onSet(superType || undefined)} style={{ ...btnStyle, background: '#805ad5' }}>Set</button>
+          <button onClick={onClose} style={btnStyle}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- Styles ---
+
+const toolbarStyle: React.CSSProperties = {
+  padding: '10px 10px', background: '#171d2b', borderBottom: '1px solid #2d3748',
+  display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0, position: 'relative',
+};
+
+const pillBtn: React.CSSProperties = {
+  background: '#4a5568', color: '#e2e8f0', border: 'none', borderRadius: 6,
+  padding: '5px 12px', cursor: 'pointer', fontSize: 11, fontWeight: 600,
+  transition: 'background 0.15s, opacity 0.15s',
+};
+
+const btnStyle: React.CSSProperties = {
+  background: '#4a5568', color: '#e2e8f0', border: 'none', borderRadius: 6,
+  padding: '6px 14px', cursor: 'pointer', fontSize: 12, fontWeight: 600,
+};
+
+const arrowBtn: React.CSSProperties = {
+  background: '#2d3748', color: '#e2e8f0', border: '1px solid #4a5568',
+  borderRadius: 6, padding: '3px 7px', cursor: 'pointer', fontSize: 14,
+  lineHeight: 1, transition: 'opacity 0.15s',
+};
+
+const sep: React.CSSProperties = {
+  width: 1, height: 20, background: '#4a5568', flexShrink: 0,
+};
+
+const legendStyle: React.CSSProperties = {
+  display: 'flex', gap: 14, marginLeft: 'auto', fontSize: 11, color: '#718096',
+};
+
+const legendItem: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', gap: 5,
+};
+
+const dot: React.CSSProperties = {
+  width: 7, height: 7, borderRadius: '50%', display: 'inline-block',
+};
+
+const dialogOverlay: React.CSSProperties = {
+  position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+  background: 'rgba(0,0,0,0.5)', zIndex: 1000,
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+};
+
+const dialogStyle: React.CSSProperties = {
+  background: '#2d3748', borderRadius: 8, padding: 20, minWidth: 320,
+  boxShadow: '0 8px 32px rgba(0,0,0,0.5)', border: '1px solid #4a5568',
+};
+
+const dialogTitle: React.CSSProperties = {
+  margin: '0 0 12px', color: '#e2e8f0', fontSize: 14,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '8px 10px', background: '#1a202c', color: '#e2e8f0',
+  border: '1px solid #4a5568', borderRadius: 4, fontSize: 13, marginTop: 8,
+  outline: 'none', boxSizing: 'border-box',
+};
+
+const fieldLabel: React.CSSProperties = {
+  display: 'block', marginTop: 8, fontSize: 11, color: '#a0aec0',
+};
+
+const dialogButtons: React.CSSProperties = {
+  display: 'flex', gap: 8, marginTop: 12,
+};
+
+const checkboxLabel: React.CSSProperties = {
+  color: '#a0aec0', fontSize: 12, display: 'flex', alignItems: 'center', gap: 4,
+};

--- a/packages/ui-concerto-editor/src/index.ts
+++ b/packages/ui-concerto-editor/src/index.ts
@@ -1,0 +1,8 @@
+export { ConcertoGraphEditor } from './components/ConcertoGraphEditor';
+export { ConceptNode } from './components/ConceptNode';
+export { EnumNode } from './components/EnumNode';
+export { MapNode } from './components/MapNode';
+export { ScalarNode } from './components/ScalarNode';
+export { parseCto, declarationsToGraph } from './utils/ctoToGraph';
+export { declarationsToCto } from './utils/graphToCto';
+export type { Declaration, Property, ConcertoModel, MapDeclaration, ImportStatement, Decorator, PropertyValidator } from './utils/types';

--- a/packages/ui-concerto-editor/src/main.tsx
+++ b/packages/ui-concerto-editor/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/ui-concerto-editor/src/utils/ctoToGraph.ts
+++ b/packages/ui-concerto-editor/src/utils/ctoToGraph.ts
@@ -1,0 +1,396 @@
+import type { Node, Edge } from '@xyflow/react';
+import type { Declaration, ConcertoModel, ImportStatement, Property, PropertyValidator, Decorator, IdentifiedKind } from './types';
+import { PRIMITIVE_TYPES } from './types';
+
+import { Parser as ParserModule } from '@accordproject/concerto-cto';
+import { ModelManager } from '@accordproject/concerto-core';
+const META = 'concerto.metamodel@1.0.0';
+
+/**
+ * Parse CTO string using the official Concerto parser (@accordproject/concerto-cto).
+ */
+export function parseCto(cto: string): ConcertoModel {
+  const ast = ParserModule.parse(cto) as any;
+
+  const namespace: string = ast.namespace;
+  const imports = parseImports(ast.imports || []);
+  const declarations = parseDeclarations(ast.declarations || []);
+
+  return { namespace, imports, declarations };
+}
+
+/**
+ * Validate a CTO string using ModelManager from @accordproject/concerto-core.
+ * Returns null if valid, or an error message string if invalid.
+ */
+export function validateCto(cto: string): string | null {
+  try {
+    const mm = new ModelManager({ enableMapType: true });
+    mm.addCTOModel(cto, 'model.cto');
+    return null;
+  } catch (e: any) {
+    return e.message || 'Validation failed';
+  }
+}
+
+// ── Import conversion ────────────────────────────────────────────
+
+function parseImports(astImports: any[]): ImportStatement[] {
+  return astImports.map((imp: any) => {
+    const $class: string = imp.$class;
+    if ($class === `${META}.ImportAll` || $class === `${META}.ImportAllFrom`) {
+      return { namespace: imp.namespace, types: ['*'], uri: imp.uri };
+    }
+    if ($class === `${META}.ImportTypes`) {
+      return { namespace: imp.namespace, types: imp.types || [], uri: imp.uri };
+    }
+    // ImportType / ImportTypeFrom
+    return { namespace: imp.namespace, types: [imp.name], uri: imp.uri };
+  });
+}
+
+// ── Declaration conversion ───────────────────────────────────────
+
+function parseDeclarations(astDecls: any[]): Declaration[] {
+  return astDecls.map((decl: any) => {
+    const $class: string = decl.$class;
+    const decorators = parseDecorators(decl.decorators || []);
+
+    // ── Scalar ──
+    if ($class.includes('Scalar')) {
+      const scalarType = $class.replace(`${META}.`, '').replace('Scalar', '');
+      return {
+        name: decl.name,
+        type: 'scalar' as const,
+        isAbstract: false,
+        properties: [],
+        enumValues: [],
+        scalarExtends: scalarType,
+        scalarValidators: parseScalarValidators(decl),
+        identified: 'none' as IdentifiedKind,
+        decorators,
+      };
+    }
+
+    // ── Map ──
+    if ($class === `${META}.MapDeclaration`) {
+      const keyType = extractMapType(decl.key);
+      const valueType = extractMapType(decl.value);
+      return {
+        name: decl.name,
+        type: 'map' as const,
+        isAbstract: false,
+        properties: [
+          { name: '_key', type: keyType, isOptional: false, isArray: false, isRelationship: false, validators: {} },
+          { name: '_value', type: valueType, isOptional: false, isArray: false, isRelationship: false, validators: {} },
+        ],
+        enumValues: [],
+        mapDeclaration: { keyType, valueType },
+        identified: 'none' as IdentifiedKind,
+        decorators,
+      };
+    }
+
+    // ── Enum ──
+    if ($class === `${META}.EnumDeclaration`) {
+      return {
+        name: decl.name,
+        type: 'enum' as const,
+        isAbstract: false,
+        properties: [],
+        enumValues: (decl.properties || []).map((p: any) => p.name),
+        identified: 'none' as IdentifiedKind,
+        decorators,
+      };
+    }
+
+    // ── Class declarations (concept, asset, participant, event, transaction) ──
+    const typeMap: Record<string, Declaration['type']> = {
+      [`${META}.ConceptDeclaration`]: 'concept',
+      [`${META}.AssetDeclaration`]: 'asset',
+      [`${META}.ParticipantDeclaration`]: 'participant',
+      [`${META}.EventDeclaration`]: 'event',
+      [`${META}.TransactionDeclaration`]: 'transaction',
+    };
+    const type = typeMap[$class] || 'concept';
+
+    // Identification
+    let identified: IdentifiedKind = 'none';
+    let identifiedBy: string | undefined;
+    if (decl.identified) {
+      if (decl.identified.$class === `${META}.IdentifiedBy`) {
+        identified = 'identified-by';
+        identifiedBy = decl.identified.name;
+      } else {
+        identified = 'identified';
+      }
+    }
+
+    return {
+      name: decl.name,
+      type,
+      isAbstract: !!decl.isAbstract,
+      superType: decl.superType?.name,
+      properties: (decl.properties || []).map(parseProperty),
+      enumValues: [],
+      identified,
+      identifiedBy,
+      decorators,
+    };
+  });
+}
+
+// ── Property conversion ──────────────────────────────────────────
+
+function parseProperty(p: any): Property {
+  const $class: string = p.$class;
+  const isRelationship = $class === `${META}.RelationshipProperty`;
+
+  let type: string;
+  if ($class === `${META}.ObjectProperty` || isRelationship) {
+    type = p.type?.name || 'String';
+  } else {
+    // BooleanProperty → Boolean, StringProperty → String, etc.
+    type = $class.replace(`${META}.`, '').replace('Property', '');
+  }
+
+  const validators: PropertyValidator = {};
+
+  if (p.defaultValue != null) validators.default = JSON.stringify(p.defaultValue);
+
+  if (p.validator) {
+    if (p.validator.pattern) {
+      validators.regex = `/${p.validator.pattern}/${p.validator.flags || ''}`;
+    }
+    if (p.validator.lower != null || p.validator.upper != null) {
+      validators.range = `[${p.validator.lower ?? ''},${p.validator.upper ?? ''}]`;
+    }
+  }
+
+  if (p.lengthValidator) {
+    validators.length = `[${p.lengthValidator.minLength ?? ''},${p.lengthValidator.maxLength ?? ''}]`;
+  }
+
+  return {
+    name: p.name,
+    type,
+    isOptional: !!p.isOptional,
+    isArray: !!p.isArray,
+    isRelationship,
+    validators,
+  };
+}
+
+// ── Decorator conversion ─────────────────────────────────────────
+
+function parseDecorators(astDecorators: any[]): Decorator[] {
+  return astDecorators.map((d: any) => ({
+    name: d.name,
+    args: (d.arguments || []).map((a: any) => {
+      if (a.$class === `${META}.DecoratorString`) return `"${a.value}"`;
+      if (a.$class === `${META}.DecoratorTypeReference`) return a.type?.name || '';
+      return String(a.value);
+    }),
+  }));
+}
+
+// ── Scalar validators ────────────────────────────────────────────
+
+function parseScalarValidators(decl: any): PropertyValidator {
+  const v: PropertyValidator = {};
+  if (decl.defaultValue != null) v.default = JSON.stringify(decl.defaultValue);
+  if (decl.validator) {
+    if (decl.validator.pattern) v.regex = `/${decl.validator.pattern}/${decl.validator.flags || ''}`;
+    if (decl.validator.lower != null || decl.validator.upper != null) {
+      v.range = `[${decl.validator.lower ?? ''},${decl.validator.upper ?? ''}]`;
+    }
+  }
+  if (decl.lengthValidator) {
+    v.length = `[${decl.lengthValidator.minLength ?? ''},${decl.lengthValidator.maxLength ?? ''}]`;
+  }
+  return v;
+}
+
+// ── Map type extraction ──────────────────────────────────────────
+
+function extractMapType(mapEntry: any): string {
+  if (mapEntry.type) return mapEntry.type.name;
+  const $class: string = mapEntry.$class;
+  return $class.replace(`${META}.`, '').replace(/Map(Key|Value)Type$/, '');
+}
+
+// ── Layout ───────────────────────────────────────────────────────
+
+function estimateNodeHeight(decl: Declaration): number {
+  let headerHeight = 70;
+  const rowHeight = 30;
+  const buttonHeight = 36;
+  const padding = 16;
+
+  if (decl.decorators?.length > 0) headerHeight += 20;
+  if (decl.identified !== 'none') headerHeight += 16;
+  if (decl.superType) headerHeight += 16;
+
+  if (decl.type === 'scalar') {
+    const constraintRows = [decl.scalarValidators?.default, decl.scalarValidators?.regex, decl.scalarValidators?.range, decl.scalarValidators?.length].filter(Boolean).length;
+    return 80 + Math.max(constraintRows, 1) * rowHeight;
+  }
+  if (decl.type === 'enum') return headerHeight + Math.max(decl.enumValues.length, 1) * rowHeight + buttonHeight + padding;
+  if (decl.type === 'map') return headerHeight + 2 * rowHeight + padding;
+  return headerHeight + Math.max(decl.properties.length, 1) * rowHeight + buttonHeight + padding;
+}
+
+function computeTreeLayout(declarations: Declaration[]): Map<string, { x: number; y: number }> {
+  const positions = new Map<string, { x: number; y: number }>();
+  if (declarations.length === 0) return positions;
+
+  const declNames = new Set(declarations.map((d) => d.name));
+
+  const refsFrom = new Map<string, Set<string>>();
+  const refsTo = new Map<string, Set<string>>();
+
+  for (const decl of declarations) {
+    if (!refsFrom.has(decl.name)) refsFrom.set(decl.name, new Set());
+
+    if (decl.superType && declNames.has(decl.superType)) {
+      refsFrom.get(decl.name)!.add(decl.superType);
+      if (!refsTo.has(decl.superType)) refsTo.set(decl.superType, new Set());
+      refsTo.get(decl.superType)!.add(decl.name);
+    }
+
+    if (decl.scalarExtends && declNames.has(decl.scalarExtends)) {
+      refsFrom.get(decl.name)!.add(decl.scalarExtends);
+    }
+
+    const props = decl.type === 'map'
+      ? decl.properties.filter((p) => p.name === '_value')
+      : decl.properties;
+    for (const prop of props) {
+      if (declNames.has(prop.type) && !PRIMITIVE_TYPES.has(prop.type) && prop.type !== decl.name) {
+        refsFrom.get(decl.name)!.add(prop.type);
+        if (!refsTo.has(prop.type)) refsTo.set(prop.type, new Set());
+        refsTo.get(prop.type)!.add(decl.name);
+      }
+    }
+  }
+
+  let root = declarations[0].name;
+  let maxScore = -Infinity;
+  for (const decl of declarations) {
+    const outCount = refsFrom.get(decl.name)?.size || 0;
+    const inCount = refsTo.get(decl.name)?.size || 0;
+    const score = outCount * 2 - inCount;
+    if (score > maxScore) { maxScore = score; root = decl.name; }
+  }
+
+  const visited = new Set<string>();
+  const layers: string[][] = [];
+  let queue = [root];
+  visited.add(root);
+
+  while (queue.length > 0) {
+    layers.push([...queue]);
+    const nextQueue: string[] = [];
+    for (const name of queue) {
+      const outRefs = refsFrom.get(name) || new Set();
+      const inRefs = refsTo.get(name) || new Set();
+      for (const connected of new Set([...outRefs, ...inRefs])) {
+        if (!visited.has(connected)) { visited.add(connected); nextQueue.push(connected); }
+      }
+    }
+    queue = nextQueue;
+  }
+
+  const unvisited = declarations.filter((d) => !visited.has(d.name)).map((d) => d.name);
+  if (unvisited.length > 0) layers.push(unvisited);
+
+  const heights = new Map<string, number>();
+  for (const decl of declarations) heights.set(decl.name, estimateNodeHeight(decl));
+
+  const spacingX = 380;
+  const gapY = 40;
+
+  for (let depth = 0; depth < layers.length; depth++) {
+    const layer = layers[depth];
+    let totalHeight = 0;
+    for (const name of layer) totalHeight += heights.get(name) || 150;
+    totalHeight += (layer.length - 1) * gapY;
+    let currentY = -totalHeight / 2;
+    for (const name of layer) {
+      const h = heights.get(name) || 150;
+      positions.set(name, { x: depth * spacingX, y: currentY });
+      currentY += h + gapY;
+    }
+  }
+
+  return positions;
+}
+
+// ── Graph generation ─────────────────────────────────────────────
+
+export function declarationsToGraph(declarations: Declaration[]): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  const declNames = new Set(declarations.map((d) => d.name));
+  const positions = computeTreeLayout(declarations);
+
+  declarations.forEach((decl) => {
+    let nodeType = 'conceptNode';
+    if (decl.type === 'enum') nodeType = 'enumNode';
+    else if (decl.type === 'map') nodeType = 'mapNode';
+    else if (decl.type === 'scalar') nodeType = 'scalarNode';
+
+    const pos = positions.get(decl.name) || { x: 0, y: 0 };
+
+    nodes.push({
+      id: decl.name,
+      type: nodeType,
+      position: pos,
+      data: { label: decl.name, declaration: decl },
+    });
+
+    // Inheritance edge
+    if (decl.superType && declNames.has(decl.superType)) {
+      edges.push({
+        id: `${decl.name}-extends-${decl.superType}`,
+        source: decl.name, target: decl.superType,
+        type: 'floating', animated: true,
+        label: 'extends',
+        style: { stroke: '#b794f4', strokeWidth: 1.5, opacity: 0.7 },
+        labelStyle: { fill: '#b794f4', fontSize: 10, fontWeight: 600 },
+        labelBgStyle: { fill: '#1a202c', fillOpacity: 0.8 },
+        labelBgPadding: [6, 3] as [number, number],
+        labelBgBorderRadius: 4,
+      });
+    }
+
+    // Property/relationship edges
+    const propsToEdge = decl.type === 'map'
+      ? decl.properties.filter((p) => p.name === '_value')
+      : decl.properties;
+
+    for (const prop of propsToEdge) {
+      if (declNames.has(prop.type) && !PRIMITIVE_TYPES.has(prop.type)) {
+        const isRel = prop.isRelationship;
+        edges.push({
+          id: `${decl.name}-${prop.name}-${prop.type}`,
+          source: decl.name, target: prop.type,
+          label: prop.name.startsWith('_') ? '' : prop.name + (prop.isArray ? '[]' : ''),
+          type: 'floating',
+          style: {
+            stroke: isRel ? '#fc8181' : '#90cdf4',
+            strokeWidth: isRel ? 1.5 : 1.2,
+            opacity: 0.6,
+            strokeDasharray: isRel ? '6 4' : undefined,
+          },
+          labelStyle: { fill: isRel ? '#fc8181' : '#90cdf4', fontSize: 10, fontWeight: 500 },
+          labelBgStyle: { fill: '#1a202c', fillOpacity: 0.8 },
+          labelBgPadding: [6, 3] as [number, number],
+          labelBgBorderRadius: 4,
+        });
+      }
+    }
+  });
+
+  return { nodes, edges };
+}

--- a/packages/ui-concerto-editor/src/utils/ctoToGraph.ts
+++ b/packages/ui-concerto-editor/src/utils/ctoToGraph.ts
@@ -25,7 +25,7 @@ export function parseCto(cto: string): ConcertoModel {
  */
 export function validateCto(cto: string): string | null {
   try {
-    const mm = new ModelManager({ enableMapType: true });
+    const mm = new ModelManager();
     mm.addCTOModel(cto, 'model.cto');
     return null;
   } catch (e: any) {

--- a/packages/ui-concerto-editor/src/utils/defaultModel.ts
+++ b/packages/ui-concerto-editor/src/utils/defaultModel.ts
@@ -1,0 +1,52 @@
+export const defaultCto = `namespace org.example.nda@1.0.0
+
+scalar SSN extends String regex=/\\d{3}-\\d{2}-\\d{4}/
+scalar Email extends String default="user@example.com"
+
+enum Jurisdiction {
+  o California
+  o NewYork
+  o Delaware
+  o Texas
+}
+
+concept Address {
+  o String street
+  o String city
+  o String zipCode length=[1,10]
+  o Jurisdiction jurisdiction
+}
+
+abstract concept Person identified by personId {
+  o String personId
+  o String name
+  o Email email optional
+  o SSN ssn optional
+}
+
+concept Party extends Person {
+  o Address address
+  o String[] tags optional
+}
+
+@Important
+asset NdaContract identified by contractId {
+  o String contractId
+  o DateTime effectiveDate
+  --> Party disclosingParty
+  --> Party receivingParty
+  o Boolean isMutual
+  o Jurisdiction jurisdiction
+  o Integer termYears range=[1,10]
+}
+
+event ContractSigned {
+  o String contractId
+  o DateTime signedDate
+}
+
+map ContactInfo {
+  o String
+  o String
+}
+`;

--- a/packages/ui-concerto-editor/src/utils/graphToCto.ts
+++ b/packages/ui-concerto-editor/src/utils/graphToCto.ts
@@ -1,0 +1,229 @@
+import type { ConcertoModel, Declaration, Property, PropertyValidator, Decorator } from './types';
+
+import { Printer as PrinterModule } from '@accordproject/concerto-cto';
+const META = 'concerto.metamodel@1.0.0';
+
+/**
+ * Convert the editor model to CTO string using the official Concerto printer
+ * (@accordproject/concerto-cto Printer.toCTO).
+ */
+export function declarationsToCto(model: ConcertoModel): string {
+  const ast = modelToMetamodel(model);
+  return PrinterModule.toCTO(ast);
+}
+
+// ── Model → Metamodel AST ────────────────────────────────────────
+
+function modelToMetamodel(model: ConcertoModel): any {
+  return {
+    namespace: model.namespace,
+    imports: model.imports.map(importToAst),
+    declarations: model.declarations.map(declarationToAst),
+  };
+}
+
+// ── Imports ──────────────────────────────────────────────────────
+
+function importToAst(imp: { namespace: string; types: string[]; uri?: string }): any {
+  if (imp.types.length === 1 && imp.types[0] === '*') {
+    return imp.uri
+      ? { $class: `${META}.ImportAllFrom`, namespace: imp.namespace, uri: imp.uri }
+      : { $class: `${META}.ImportAll`, namespace: imp.namespace };
+  }
+  if (imp.types.length === 1) {
+    return imp.uri
+      ? { $class: `${META}.ImportTypeFrom`, namespace: imp.namespace, name: imp.types[0], uri: imp.uri }
+      : { $class: `${META}.ImportType`, namespace: imp.namespace, name: imp.types[0] };
+  }
+  return { $class: `${META}.ImportTypes`, namespace: imp.namespace, types: imp.types, uri: imp.uri };
+}
+
+// ── Declarations ─────────────────────────────────────────────────
+
+function declarationToAst(decl: Declaration): any {
+  const decorators = decl.decorators.map(decoratorToAst);
+
+  // ── Scalar ──
+  if (decl.type === 'scalar') {
+    const scalarClass = `${META}.${decl.scalarExtends || 'String'}Scalar`;
+    const result: any = { $class: scalarClass, name: decl.name };
+    if (decorators.length) result.decorators = decorators;
+    if (decl.scalarValidators) addValidatorsToAst(result, decl.scalarValidators, decl.scalarExtends || 'String');
+    return result;
+  }
+
+  // ── Map ──
+  if (decl.type === 'map') {
+    const keyType = decl.mapDeclaration?.keyType || 'String';
+    const valueType = decl.mapDeclaration?.valueType || 'String';
+    const result: any = {
+      $class: `${META}.MapDeclaration`,
+      name: decl.name,
+      key: mapTypeToAst(keyType, 'Key'),
+      value: mapTypeToAst(valueType, 'Value'),
+    };
+    if (decorators.length) result.decorators = decorators;
+    return result;
+  }
+
+  // ── Enum ──
+  if (decl.type === 'enum') {
+    const result: any = {
+      $class: `${META}.EnumDeclaration`,
+      name: decl.name,
+      properties: decl.enumValues.map((v) => ({ $class: `${META}.EnumProperty`, name: v })),
+    };
+    if (decorators.length) result.decorators = decorators;
+    return result;
+  }
+
+  // ── Class declarations ──
+  const classMap: Record<string, string> = {
+    concept: `${META}.ConceptDeclaration`,
+    asset: `${META}.AssetDeclaration`,
+    participant: `${META}.ParticipantDeclaration`,
+    event: `${META}.EventDeclaration`,
+    transaction: `${META}.TransactionDeclaration`,
+  };
+
+  const result: any = {
+    $class: classMap[decl.type] || `${META}.ConceptDeclaration`,
+    name: decl.name,
+    isAbstract: decl.isAbstract,
+    properties: decl.properties.map(propertyToAst),
+  };
+
+  if (decl.superType) {
+    result.superType = { name: decl.superType };
+  }
+
+  if (decl.identified === 'identified-by' && decl.identifiedBy) {
+    result.identified = { $class: `${META}.IdentifiedBy`, name: decl.identifiedBy };
+  } else if (decl.identified === 'identified') {
+    result.identified = { $class: `${META}.Identified` };
+  }
+
+  if (decorators.length) result.decorators = decorators;
+
+  return result;
+}
+
+// ── Properties ───────────────────────────────────────────────────
+
+const PRIMITIVE_TO_CLASS: Record<string, string> = {
+  String: 'StringProperty',
+  Integer: 'IntegerProperty',
+  Long: 'LongProperty',
+  Double: 'DoubleProperty',
+  Boolean: 'BooleanProperty',
+  DateTime: 'DateTimeProperty',
+};
+
+function propertyToAst(prop: Property): any {
+  if (prop.isRelationship) {
+    return {
+      $class: `${META}.RelationshipProperty`,
+      name: prop.name,
+      type: { name: prop.type },
+      isArray: prop.isArray,
+      isOptional: prop.isOptional,
+    };
+  }
+
+  const primitiveClass = PRIMITIVE_TO_CLASS[prop.type];
+  if (primitiveClass) {
+    const result: any = {
+      $class: `${META}.${primitiveClass}`,
+      name: prop.name,
+      isArray: prop.isArray,
+      isOptional: prop.isOptional,
+    };
+    addValidatorsToAst(result, prop.validators, prop.type);
+    return result;
+  }
+
+  // Object property (reference to another declaration)
+  const result: any = {
+    $class: `${META}.ObjectProperty`,
+    name: prop.name,
+    type: { name: prop.type },
+    isArray: prop.isArray,
+    isOptional: prop.isOptional,
+  };
+  if (prop.validators?.default) result.defaultValue = prop.validators.default;
+  return result;
+}
+
+// ── Validators ───────────────────────────────────────────────────
+
+function addValidatorsToAst(result: any, validators: PropertyValidator, typeName: string) {
+  if (!validators) return;
+
+  if (validators.default != null) {
+    const val = validators.default;
+    const unquoted = val.replace(/^["']|["']$/g, '');
+    if (typeName === 'Boolean') result.defaultValue = unquoted === 'true';
+    else if (['Integer', 'Long', 'Double'].includes(typeName)) result.defaultValue = Number(unquoted);
+    else result.defaultValue = unquoted;
+  }
+
+  if (validators.regex) {
+    const match = validators.regex.match(/^\/(.*)\/([gimsuy]*)$/);
+    if (match) {
+      result.validator = { pattern: match[1], flags: match[2] };
+    }
+  }
+
+  if (validators.range) {
+    const match = validators.range.match(/^\[([^,]*),([^\]]*)\]$/);
+    if (match) {
+      result.validator = result.validator || {};
+      if (match[1].trim()) result.validator.lower = Number(match[1].trim());
+      if (match[2].trim()) result.validator.upper = Number(match[2].trim());
+    }
+  }
+
+  if (validators.length) {
+    const match = validators.length.match(/^\[([^,]*),([^\]]*)\]$/);
+    if (match) {
+      result.lengthValidator = {};
+      if (match[1].trim()) result.lengthValidator.minLength = Number(match[1].trim());
+      if (match[2].trim()) result.lengthValidator.maxLength = Number(match[2].trim());
+    }
+  }
+}
+
+// ── Map types ────────────────────────────────────────────────────
+
+const PRIMITIVE_MAP_KEY_TYPES = new Set(['String', 'DateTime']);
+const PRIMITIVE_MAP_VALUE_TYPES = new Set(['String', 'DateTime', 'Integer', 'Long', 'Double', 'Boolean']);
+
+function mapTypeToAst(typeName: string, kind: 'Key' | 'Value'): any {
+  const primitives = kind === 'Key' ? PRIMITIVE_MAP_KEY_TYPES : PRIMITIVE_MAP_VALUE_TYPES;
+  if (primitives.has(typeName)) {
+    return { $class: `${META}.${typeName}Map${kind}Type` };
+  }
+  const $class = kind === 'Key' ? `${META}.ObjectMapKeyType` : `${META}.ObjectMapValueType`;
+  return { $class, type: { name: typeName } };
+}
+
+// ── Decorators ───────────────────────────────────────────────────
+
+function decoratorToAst(dec: Decorator): any {
+  const result: any = { name: dec.name };
+  if (dec.args.length > 0) {
+    result.arguments = dec.args.map((arg) => {
+      if ((arg.startsWith('"') && arg.endsWith('"')) || (arg.startsWith("'") && arg.endsWith("'"))) {
+        return { $class: `${META}.DecoratorString`, value: arg.slice(1, -1) };
+      }
+      if (!isNaN(Number(arg))) {
+        return { $class: `${META}.DecoratorNumber`, value: Number(arg) };
+      }
+      if (arg === 'true' || arg === 'false') {
+        return { $class: `${META}.DecoratorBoolean`, value: arg === 'true' };
+      }
+      return { $class: `${META}.DecoratorTypeReference`, type: { name: arg } };
+    });
+  }
+  return result;
+}

--- a/packages/ui-concerto-editor/src/utils/types.ts
+++ b/packages/ui-concerto-editor/src/utils/types.ts
@@ -1,0 +1,138 @@
+export interface PropertyValidator {
+  default?: string;
+  regex?: string;
+  range?: string;      // e.g. "[1,100]"
+  length?: string;     // e.g. "[1,100]"
+}
+
+export interface Property {
+  name: string;
+  type: string;
+  isOptional: boolean;
+  isArray: boolean;
+  isRelationship: boolean;
+  validators: PropertyValidator;
+}
+
+export interface MapDeclaration {
+  keyType: string;
+  valueType: string;
+}
+
+export interface Decorator {
+  name: string;
+  args: string[];
+}
+
+export type IdentifiedKind = 'none' | 'identified' | 'identified-by';
+
+export interface Declaration {
+  name: string;
+  type: 'concept' | 'enum' | 'asset' | 'participant' | 'event' | 'transaction' | 'map' | 'scalar';
+  isAbstract: boolean;
+  superType?: string;
+  properties: Property[];
+  enumValues: string[];
+  mapDeclaration?: MapDeclaration;
+  // Scalar
+  scalarExtends?: string;  // e.g. "String"
+  scalarValidators?: PropertyValidator;
+  // Identity
+  identified: IdentifiedKind;
+  identifiedBy?: string;   // field name for "identified by"
+  // Decorators
+  decorators: Decorator[];
+}
+
+export interface ImportStatement {
+  namespace: string;
+  types: string[];
+  uri?: string;
+}
+
+export interface ConcertoModel {
+  namespace: string;
+  imports: ImportStatement[];
+  declarations: Declaration[];
+}
+
+export const PRIMITIVE_TYPES = new Set([
+  'String', 'Integer', 'Long', 'Double', 'Boolean', 'DateTime',
+]);
+
+export const ALL_TYPES = [
+  'String', 'Integer', 'Long', 'Double', 'Boolean', 'DateTime',
+];
+
+export const DECLARATION_TYPES = [
+  'concept', 'enum', 'asset', 'participant', 'event', 'transaction', 'map', 'scalar',
+] as const;
+
+/**
+ * Get all available types for property/map dropdowns.
+ * Includes primitives + all declaration names (concepts, enums, scalars, etc.)
+ */
+export function getAvailableTypes(declarations: Declaration[], exclude?: string): string[] {
+  const declNames = declarations.map((d) => d.name).filter((n) => n !== exclude);
+  return [...ALL_TYPES, ...declNames];
+}
+
+/**
+ * Map key/value type constraints per Concerto spec.
+ * Keys: primitives String/DateTime, plus scalars extending them.
+ * Values: primitives String/DateTime/Integer/Long/Double/Boolean, plus
+ * scalars extending String/Integer/Long/Double/Boolean, plus concepts.
+ */
+export const MAP_KEY_PRIMITIVES = ['String', 'DateTime'];
+export const MAP_VALUE_PRIMITIVES = ['String', 'DateTime', 'Integer', 'Long', 'Double', 'Boolean'];
+const MAP_KEY_SCALAR_BASES = new Set(['String', 'DateTime']);
+const MAP_VALUE_SCALAR_BASES = new Set(['String', 'Integer', 'Long', 'Double', 'Boolean']);
+const CLASS_DECL_TYPES = new Set(['concept', 'asset', 'participant', 'event', 'transaction']);
+
+export function getMapKeyTypes(declarations: Declaration[]): string[] {
+  const scalars = declarations
+    .filter((d) => d.type === 'scalar' && d.scalarExtends && MAP_KEY_SCALAR_BASES.has(d.scalarExtends))
+    .map((d) => d.name);
+  return [...MAP_KEY_PRIMITIVES, ...scalars];
+}
+
+export function getMapValueTypes(declarations: Declaration[]): string[] {
+  const scalars = declarations
+    .filter((d) => d.type === 'scalar' && d.scalarExtends && MAP_VALUE_SCALAR_BASES.has(d.scalarExtends))
+    .map((d) => d.name);
+  const concepts = declarations
+    .filter((d) => CLASS_DECL_TYPES.has(d.type))
+    .map((d) => d.name);
+  return [...MAP_VALUE_PRIMITIVES, ...scalars, ...concepts];
+}
+
+/**
+ * Get valid candidates for "extends" on a given declaration.
+ * Only same-kind declarations (no enums, no maps, no scalars), excluding self and checking for cycles.
+ */
+export function getExtendsCandidates(declarations: Declaration[], declName: string): string[] {
+  const decl = declarations.find((d) => d.name === declName);
+  if (!decl) return [];
+
+  // Build ancestor set to prevent cycles
+  const ancestors = new Set<string>();
+  const collectDescendants = (name: string) => {
+    for (const d of declarations) {
+      if (d.superType === name && !ancestors.has(d.name)) {
+        ancestors.add(d.name);
+        collectDescendants(d.name);
+      }
+    }
+  };
+  collectDescendants(declName);
+
+  return declarations
+    .filter((d) =>
+      d.name !== declName &&
+      d.type !== 'enum' &&
+      d.type !== 'map' &&
+      d.type !== 'scalar' &&
+      !ancestors.has(d.name)
+    )
+    .map((d) => d.name);
+}

--- a/packages/ui-concerto-editor/tsconfig.json
+++ b/packages/ui-concerto-editor/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationDir": "lib",
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/packages/ui-concerto-editor/vite.config.ts
+++ b/packages/ui-concerto-editor/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default defineConfig({
+  plugins: [react(), nodePolyfills()],
+  optimizeDeps: {
+    include: ['@accordproject/concerto-cto', '@accordproject/concerto-core'],
+  },
+  server: {
+    port: 3001,
+  },
+});


### PR DESCRIPTION
## Summary

Adds a new `@accordproject/ui-concerto-editor` package providing a graphical (visual) editor for Concerto data models using React Flow (`@xyflow/react`).

- **Visual model editing** — drag-and-drop canvas with concept, enum, map, and scalar nodes
- **Bi-directional sync** — changes in the graphical editor update the CTO text and vice versa
- **Relationship/inheritance wiring** — drag edges between nodes to add properties, relationships, or `extends` declarations
- **Undo/redo** — Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z keyboard shortcuts with full history
- **Import/export** — toolbar actions to bring in or export CTO text

### Changes

- `packages/ui-concerto-editor/` — new package: React Flow-based graphical editor components
- Fix TypeScript errors: `useNodesState`/`useEdgesState` explicit type parameters (`Node[]`/`Edge[]`)
- Remove deprecated `enableMapType` option (enabled by default in concerto-core v4)
- Upgrade `@accordproject/concerto-core` and `concerto-cto` from `^3.x` to `^4.1.0`
- Upgrade `@xyflow/react` from `^12.0.0` to `^12.10.2`
- Upgrade `vite-plugin-node-polyfills` to `^0.26.0`, align `@types/react*` to `^18.3.0`

### Flags

- The new package uses Vite for its own build, separate from the Lerna/Rollup pipeline used by other packages
- Bundle size is large (~1.5 MB minified) due to React Flow — code-splitting is a future improvement

### Related Issues

- Closes #448

### Author Checklist

- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
- [ ] Manual accessibility test performed
    - [ ] Keyboard-only access, including forms
    - [ ] Contrast at least WCAG Level A
    - [ ] Appropriate labels, alt text, and instructions