### PR TITLE
fix(ci): update deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,14 @@ jobs:
 
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: npm-and-build-cache
         with:
           path: |
@@ -75,10 +75,10 @@ jobs:
 
     steps:
       - name: git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
     


### PR DESCRIPTION
## Summary

- `actions/cache@v2`, `actions/checkout@v2`, and `actions/setup-node@v1` are now blocked by GitHub and causing all CI runs to fail immediately
- Updates all three to `v4` in both the `build` and `publish` jobs of `build.yml`

This unblocks PR #449 and all other open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)